### PR TITLE
Feat/#60 공통 에러 코드 및 GlobalExceptionHandler 구현

### DIFF
--- a/src/main/java/io/dev/jobprep/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/dev/jobprep/exception/GlobalExceptionHandler.java
@@ -1,0 +1,111 @@
+package io.dev.jobprep.exception;
+
+import static io.dev.jobprep.exception.code.ErrorCode400.INVALID_INPUT_VALUE;
+import static io.dev.jobprep.exception.code.ErrorCode400.PATH_PARAMETER_BAD_REQUEST;
+import static io.dev.jobprep.exception.code.ErrorCode401.AUTH_MISSING_CREDENTIALS;
+import static io.dev.jobprep.exception.code.ErrorCode401.AUTH_TOKEN_EXPIRED;
+import static io.dev.jobprep.exception.code.ErrorCode403.AUTH_ACCESS_DENIED;
+import static io.dev.jobprep.exception.code.ErrorCode500.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import io.dev.jobprep.exception.dto.ErrorResponse;
+import io.dev.jobprep.exception.excception_class.CustomException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {CustomException.class})
+    protected ResponseEntity<ErrorResponse> handleCustomException(
+        CustomException e, HttpServletRequest request
+    ) {
+        log.info("Custom Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        return ErrorResponse.from(e.getErrorCode());
+    }
+
+    @ExceptionHandler(value = {
+        BindException.class,
+        MethodArgumentNotValidException.class
+    })
+    protected ResponseEntity<ErrorResponse> validationException(
+        BindException e, HttpServletRequest request
+    ) {
+        log.info("Validation Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder builder = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            builder.append("[");
+            builder.append(fieldError.getField());
+            builder.append("] (은)는 ");
+            builder.append(fieldError.getDefaultMessage());
+            builder.append(" 입력된 값: [");
+            builder.append(fieldError.getRejectedValue());
+            builder.append("]");
+            builder.append(", ");
+        }
+        log.info(builder.toString());
+
+        return ErrorResponse.ofWithErrorMessage(INVALID_INPUT_VALUE, builder.toString());
+    }
+
+    @ExceptionHandler(value = {
+        MissingPathVariableException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ErrorResponse> missingPathVariableException(
+        Exception e, HttpServletRequest request
+    ) {
+        log.info("Missing Path Variable Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        return ErrorResponse.from(PATH_PARAMETER_BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = {TokenExpiredException.class})
+    protected ResponseEntity<ErrorResponse> handleTokenExpiredException(
+        TokenExpiredException e, HttpServletRequest request
+
+    ) {
+        log.info("Token Expiry Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        return ErrorResponse.from(AUTH_TOKEN_EXPIRED);
+    }
+
+    @ExceptionHandler(value = {AuthenticationException.class, JWTVerificationException.class})
+    protected ResponseEntity<ErrorResponse> handleAuthenticationException(
+        AuthenticationException e, HttpServletRequest request
+    ) {
+        log.info("Authentication Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        log.info("Token: {}", request.getHeader(AUTHORIZATION));
+        return ErrorResponse.from(AUTH_MISSING_CREDENTIALS);
+    }
+
+    @ExceptionHandler(value = {AccessDeniedException.class})
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(
+        AccessDeniedException e, HttpServletRequest request
+    ) {
+        log.info("Access Denied Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        return ErrorResponse.from(AUTH_ACCESS_DENIED);
+    }
+
+    @ExceptionHandler(value = Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(
+        Exception e, HttpServletRequest request
+    ) {
+        log.info("Exception: {}, Path: {}", e.getMessage(), request.getPathInfo());
+        return ErrorResponse.from(INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/dev/jobprep/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import io.dev.jobprep.exception.dto.ErrorResponse;
-import io.dev.jobprep.exception.excception_class.CustomException;
+import io.dev.jobprep.exception.exception_class.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode.java
@@ -1,0 +1,11 @@
+package io.dev.jobprep.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+
+}

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -1,0 +1,22 @@
+package io.dev.jobprep.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode400 implements ErrorCode {
+    PATH_PARAMETER_BAD_REQUEST("E00-COMMON-001", "잘못된 경로 파라미터입니다."),
+    INVALID_INPUT_VALUE("E00-COMMON-002", "기본 유효성 검사에 실패하였습니다."),
+
+    INVALID_STUDY_STATUS_TO_RECRUIT("E01-STUDY-001", "스터디가 현재 모집중이 아닙니다."),
+    ;
+
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+    private final String code;
+    private final String message;
+
+    ErrorCode400(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode401.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode401.java
@@ -1,0 +1,21 @@
+package io.dev.jobprep.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode401 implements ErrorCode {
+
+    AUTH_MISSING_CREDENTIALS("E02-AUTH-001", "사용자의 인증 정보를 찾을 수 없습니다."),
+    AUTH_TOKEN_EXPIRED("E02-AUTH-002", "토큰이 만료되었습니다."),
+    ;
+
+    private final HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
+    private final String code;
+    private final String message;
+
+    ErrorCode401(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode403.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode403.java
@@ -1,0 +1,20 @@
+package io.dev.jobprep.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode403 implements ErrorCode {
+
+    AUTH_ACCESS_DENIED("E02-AUTH-001", "접근 권한이 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;
+    private final String code;
+    private final String message;
+
+    ErrorCode403(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode404.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode404.java
@@ -1,0 +1,18 @@
+package io.dev.jobprep.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode404 implements ErrorCode {
+    ;
+
+    private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+    private final String code;
+    private final String message;
+
+    ErrorCode404(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode500.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode500.java
@@ -1,0 +1,20 @@
+package io.dev.jobprep.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode500 implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR("E99-SERVER-001", "서버에서 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    ;
+
+    private final HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+    private final String code;
+    private final String message;
+
+    ErrorCode500(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/dto/ErrorResponse.java
+++ b/src/main/java/io/dev/jobprep/exception/dto/ErrorResponse.java
@@ -1,0 +1,43 @@
+package io.dev.jobprep.exception.dto;
+
+import io.dev.jobprep.exception.code.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Schema(description = "에러 응답")
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int statusCode;
+    private final String code;
+    private final String message;
+
+    public static ResponseEntity<ErrorResponse> from(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.builder()
+                .statusCode(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build()
+            );
+    }
+
+    public static ResponseEntity<ErrorResponse> ofWithErrorMessage(
+        ErrorCode errorCode, String message
+    ) {
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.builder()
+                .statusCode(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(message)
+                .build()
+            );
+    }
+}

--- a/src/main/java/io/dev/jobprep/exception/excception_class/CustomException.java
+++ b/src/main/java/io/dev/jobprep/exception/excception_class/CustomException.java
@@ -1,0 +1,16 @@
+package io.dev.jobprep.exception.excception_class;
+
+import io.dev.jobprep.exception.code.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/exception/exception_class/CustomException.java
+++ b/src/main/java/io/dev/jobprep/exception/exception_class/CustomException.java
@@ -1,4 +1,4 @@
-package io.dev.jobprep.exception.excception_class;
+package io.dev.jobprep.exception.exception_class;
 
 import io.dev.jobprep.exception.code.ErrorCode;
 import lombok.Getter;

--- a/src/main/resources/db/migration/V2__ADD_CREATOR_TO_STUDY.sql
+++ b/src/main/resources/db/migration/V2__ADD_CREATOR_TO_STUDY.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study ADD COLUMN user_id BIGINT NOT NULL COMMENT '스터디 생성자 ID'


### PR DESCRIPTION
## 🚀 개발 사항
- [x] unchecked Exception 처리를 위한 `CustomException` 구현
- [x] `ErrorCode` 인터페이스 구현
- [x] 해당 인터페이스를 상속하는 status별 ErrorCode 클래스 구현
- [x] ErrorResponse dto 구현
- [x] GlobalExceptionHandler 구현    

### 이슈 번호
- close #60

## 특이 사항 🫶

![image](https://github.com/user-attachments/assets/63970c1b-db0c-4701-b2bf-403c8c937e33)

현재 custom errorCode 명명 규칙은 `E(에러종류)-(도메인명)-(시퀀스)` 로 설정해두었습니다.
예) `Study` 도메인에서 도메인 로직 상의 오류일 경우 `E01-STUDY-001` 다음과 같이 작성할 수 있습니다. 
혹시 다른 이견이나 좋은 의견 있다면 코멘트 남겨주셔도 좋을 것 같습니다!

현재 `RuntimeException` 을 상속하는 CustomException 클래스를 생성해두었습니다.
도메인 구현하시면서 해당 도메인에 대한 Exception 클래스 생성하실 때 해당 클래스를 상속받아서 `super` 메서드로 errorCode 전달해주세요!

```java
class StudyException extends CustomException {
   
   public StudyException(ErrorCode errorCode) {
     super(errorCode);
   }
}
```
 
그리고 예외를 던지실 때는 다음과 같이 작성해주시면 됩니다.

```java
if (~~) {
   throw new StudyException(INVALID_STUDY_STATUS, "에러 메시지 작성"; // 1번
   throw new StudyException(INVALID_STUDY_STATUS); // 2번
} 
```

애러 메시지를 같이 전달해야 하는 경우에는 1번, 아닌 경우에는 2번 방식을 선택하시면 됩니다. 그리고 arg로 전달하는 값은 ErrorCode 인터페이스를 상속한 클래스의 enum 값으로 적어주시면 됩니다.

예를 들어, 400 에러에 대해 작성해야 하는 경우, `errorCode400` 클래스에 해당 예외에 대한 enum을 custom-error-code와 message를 적어서 작성해주시고 arg로 전달해주시면 됩니다.