### PR TITLE
[REFACT] application_status 도메인 enum 타입 컬럼 default 제거, 조회 필드에 coverLetter 추가

### DIFF
--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/enums/ApplicationProcess.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/enums/ApplicationProcess.java
@@ -22,7 +22,7 @@ public enum ApplicationProcess {
     }
 
     public static ApplicationProcess from(String description) {
-        if (description == null) return DOCUMENT_SCREENING;
+        if (description == null) return null;
         return Arrays.stream(ApplicationProcess.values())
             .filter(process -> process.getDescription().equals(description))
             .findFirst()

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/enums/ApplicationProgress.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/enums/ApplicationProgress.java
@@ -22,7 +22,7 @@ public enum ApplicationProgress {
     }
 
     public static ApplicationProgress from(String description) {
-        if (description == null) return NOT_STARTED;
+        if (description == null) return null;
         return Arrays.stream(ApplicationProgress.values())
             .filter(progress -> progress.getDescription().equals(description))
             .findFirst()

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusCommonResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusCommonResponse.java
@@ -45,6 +45,10 @@ public class ApplicationStatusCommonResponse {
     @Nullable
     private final String url;
 
+    @Schema(description = "자기소개서", example = "저를 꼭 뽑아주세요!", implementation = String.class)
+    @Nullable
+    private final String coverLetter;
+
     @Builder
     private ApplicationStatusCommonResponse(
         Long id,
@@ -54,7 +58,8 @@ public class ApplicationStatusCommonResponse {
         ApplicationProcess process,
         LocalDateTime applicationDate,
         LocalDateTime dueDate,
-        String url
+        String url,
+        String coverLetter
     ) {
         this.id = id;
         this.company = company;
@@ -64,6 +69,7 @@ public class ApplicationStatusCommonResponse {
         this.applicationDate = applicationDate;
         this.dueDate = dueDate;
         this.url = url;
+        this.coverLetter = coverLetter;
     }
 
     public static ApplicationStatusCommonResponse from(ApplicationStatus applicationStatus) {
@@ -76,6 +82,7 @@ public class ApplicationStatusCommonResponse {
             .applicationDate(applicationStatus.getApplicationDate())
             .dueDate(applicationStatus.getDueDate())
             .url(applicationStatus.getUrl())
+            .coverLetter(applicationStatus.getCoverLetter())
             .build();
     }
 

--- a/src/main/resources/db/migration/V14__REMOVE_APPLICATION_STATUS_DEFAULT.sql
+++ b/src/main/resources/db/migration/V14__REMOVE_APPLICATION_STATUS_DEFAULT.sql
@@ -1,0 +1,5 @@
+ALTER TABLE application_status
+ALTER COLUMN application_progress DROP DEFAULT;
+
+ALTER TABLE application_status
+ALTER COLUMN application_process DROP DEFAULT;


### PR DESCRIPTION
## 🚀 개발 사항
- [x] `application_status` 도메인의 enum 타입 필드에 `default` 값 제거
- [x] `application_status` 조회 API 필드에 `coverLetter` 추가 

### 이슈 번호
- close #82

## 특이 사항 🫶 
