### PR TITLE
Feat/#83 oauth login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core:10.8.1'
 	implementation 'org.flywaydb:flyway-mysql:10.8.1'
 
+	// OAuth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// SpringBoot Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.8'
 	// TestContainers

--- a/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
@@ -1,15 +1,46 @@
 package io.dev.jobprep.core.configuration;
 
+import io.dev.jobprep.security.oauth.CustomOAuth2UserService;
+import io.dev.jobprep.security.oauth.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
-@EnableWebSecurity
+@RequiredArgsConstructor
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService oAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+
+                .authorizeHttpRequests(request ->
+                        request.anyRequest().permitAll()
+                )
+
+                .oauth2Login(oauth ->
+                        oauth.userInfoEndpoint(oa -> oa.userService(oAuth2UserService))
+                                .successHandler(oAuth2SuccessHandler)
+
+                );
+
+        return http.build();
+    }
 
     @Bean
     SecurityFilterChain filterChainApi(HttpSecurity httpSecurity) throws Exception {

--- a/src/main/java/io/dev/jobprep/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/io/dev/jobprep/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,45 @@
+package io.dev.jobprep.security.oauth;
+
+import io.dev.jobprep.domain.users.domain.User;
+import io.dev.jobprep.domain.users.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, oAuth2UserAttributes);
+
+        User user = getOrSave(attributes);
+
+        return new PrincipalDetails(user, oAuth2UserAttributes, userNameAttributeName);
+    }
+
+    private User getOrSave (OAuthAttributes attributes) {
+        User user = userRepository.findUserByEmail(attributes.getEmail())
+                .orElseGet(attributes::toEntity);
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/io/dev/jobprep/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/io/dev/jobprep/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,24 @@
+package io.dev.jobprep.security.oauth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+
+    }
+}

--- a/src/main/java/io/dev/jobprep/security/oauth/OAuthAttributes.java
+++ b/src/main/java/io/dev/jobprep/security/oauth/OAuthAttributes.java
@@ -1,0 +1,81 @@
+package io.dev.jobprep.security.oauth;
+
+import io.dev.jobprep.domain.users.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Getter
+@ToString
+@Slf4j
+public class OAuthAttributes {
+    private Map<String, Object> attributes;     // OAuth2 반환하는 유저 정보
+    private String name;
+    private String email;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String name, String email) {
+        this.attributes = attributes;
+        this.name = name;
+        this.email = email;
+    }
+
+    public static OAuthAttributes of(String socialName, Map<String, Object> attributes) {
+        if ("kakao".equals(socialName)) {
+            return ofKakao(attributes);
+        } else if ("google".equals(socialName)) {
+            return ofGoogle(attributes);
+        } else if ("naver".equals(socialName)) {
+            return ofNaver(attributes);
+        }
+        return null;
+    }
+
+    private static OAuthAttributes ofGoogle(Map<String, Object> attributes) {
+        String name = String.valueOf(attributes.get("name"));
+        String email = String.valueOf(attributes.get("email"));
+
+        return OAuthAttributes.builder()
+                .name(name)
+                .email(email)
+                .attributes(attributes)
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String name = String.valueOf(kakaoProfile.get("nickname"));
+        String email = String.valueOf(kakaoAccount.get("email"));
+
+        return OAuthAttributes.builder()
+                .name(name)
+                .email(email)
+                .attributes(attributes)
+                .build();
+    }
+
+    public static OAuthAttributes ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        String name = String.valueOf(response.get("name"));
+        String email = String.valueOf(response.get("email"));
+
+        return OAuthAttributes.builder()
+                .name(name)
+                .email(email)
+                .attributes(attributes)
+                .build();
+    }
+
+    public User toEntity () {
+        return User.builder()
+                .username(name)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/io/dev/jobprep/security/oauth/OAuthAttributes.java
+++ b/src/main/java/io/dev/jobprep/security/oauth/OAuthAttributes.java
@@ -12,9 +12,9 @@ import java.util.Map;
 @ToString
 @Slf4j
 public class OAuthAttributes {
-    private Map<String, Object> attributes;     // OAuth2 반환하는 유저 정보
-    private String name;
-    private String email;
+    private final Map<String, Object> attributes;     // OAuth2 반환하는 유저 정보
+    private final String name;
+    private final String email;
 
     @Builder
     public OAuthAttributes(Map<String, Object> attributes, String name, String email) {

--- a/src/main/java/io/dev/jobprep/security/oauth/PrincipalDetails.java
+++ b/src/main/java/io/dev/jobprep/security/oauth/PrincipalDetails.java
@@ -1,0 +1,62 @@
+package io.dev.jobprep.security.oauth;
+
+import io.dev.jobprep.domain.users.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public record PrincipalDetails (
+        User user,
+        Map<String, Object> attributes,
+        String attributeKey ) implements OAuth2User, UserDetails {
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(user.getUserRole().toString()));
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항

- [x] spring security OAuth 를 사용하여 소셜 로그인 구현
- [x] kakao, naver, google dto 집합체 생성
- [x] 받아온 attributes 를 dto 로 변환
- [x] 받아온 정보를 sql 에 저장 
- [ ] oauth 로그인 성공 후 url 설정

### 이슈 번호
- close 83

## 특이 사항 🫶 
- 소셜 로그인 요청 url : http://{domain}/oauth2/authorization/{registrationId}
- 로그인 성공 후 redirect url 은 따로 구현하지 않음
- 로그인 성공 후 jwt 발급 받는 로직 추가해야 함
- 소셜 로그인 코드 요청 redirect-uri 는 현재는 localhost 로 설정해 둠, 업데이트가 필요