### PR TITLE
[BUG] 스터디 시작일자 관련 500 에러를 400 에러로 포장

### DIFF
--- a/src/main/java/io/dev/jobprep/domain/study/application/StudyService.java
+++ b/src/main/java/io/dev/jobprep/domain/study/application/StudyService.java
@@ -4,6 +4,7 @@ import static io.dev.jobprep.exception.code.ErrorCode400.ALREADY_CREATED_STUDY;
 import static io.dev.jobprep.exception.code.ErrorCode400.ALREADY_GATHERED_STUDY;
 import static io.dev.jobprep.exception.code.ErrorCode400.ALREADY_PASSED_DUE_DATE;
 import static io.dev.jobprep.exception.code.ErrorCode400.DUPLICATE_STUDY_NAME;
+import static io.dev.jobprep.exception.code.ErrorCode400.INVALID_START_DATE;
 import static io.dev.jobprep.exception.code.ErrorCode400.STUDY_GATHERED_USER_EXCEED;
 import static io.dev.jobprep.exception.code.ErrorCode403.USER_PERMISSION_SUSPENDED;
 import static io.dev.jobprep.exception.code.ErrorCode404.STUDY_NOT_FOUND;
@@ -67,7 +68,11 @@ public class StudyService {
         }
 
         StudyScheduleCreateRequest scheduleReq = req.from(study);
-        studyScheduleService.create(id, scheduleReq);
+        try {
+            studyScheduleService.create(id, scheduleReq);
+        } catch (ConstraintViolationException e) {
+            throw new StudyException(INVALID_START_DATE);
+        }
 
         return study.getId();
     }

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -21,6 +21,7 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_STATUS_ARG("E01-STUDY-010", "스터디 상태가 잘못되었습니다."),
     NON_GATHERED_USER("E01-STUDY-011", "해당 스터디에 유저가 존재하지 않습니다."),
     DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
+    INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),
 
     USER_ACCOUNT_ALREADY_EXISTS("E01-USER-001", "해당 이메일로 가입된 계정이 이미 존재합니다."),
     ALREADY_PENALIZED_USER("E01-USER-002", "이미 페널티가 부여된 유저입니다."),


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 스터디 시작일자의 Validation 실패 시에 발생하는 500 에러를 400 에러로 포장 후 던지기로 변경

### 이슈 번호
- close #85

## 특이 사항 🫶 
