### PR TITLE
Feat/#186 scheduling for study (+ internal API 호출 제한을 위한 IP white-list 관리)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
 	// Spring Boot Security
 	implementation 'org.springframework.boot:spring-boot-starter-security:3.1.8'
+	// Spring Retry
+	implementation 'org.springframework.retry:spring-retry'
 	// JWT
 	implementation 'com.auth0:java-jwt:4.4.0'
 	// Swagger
@@ -49,6 +51,13 @@ dependencies {
 	// Flyway
 	implementation 'org.flywaydb:flyway-core:10.8.1'
 	implementation 'org.flywaydb:flyway-mysql:10.8.1'
+	// Slack
+	implementation 'com.slack.api:bolt:1.39.0'
+	implementation 'com.slack.api:bolt-servlet:1.39.0'
+	implementation 'com.slack.api:bolt-jetty:1.39.0'
+	implementation 'org.slf4j:slf4j-simple:1.7.36'
+	// Spring Boot MailSender
+	implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.8'
 
 	// SpringBoot Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.8'

--- a/src/main/java/io/dev/jobprep/common/alert/mail/PrettyPrintHelper.java
+++ b/src/main/java/io/dev/jobprep/common/alert/mail/PrettyPrintHelper.java
@@ -1,0 +1,17 @@
+package io.dev.jobprep.common.alert.mail;
+
+public class PrettyPrintHelper {
+
+    public static final String BOLD_STRT = "<h3>";
+    public static final String BOLD_END = "</h3>";
+    public static final String LIGHT_BOLD_STRT = "<p><b>";
+    public static final String LIGHT_BOLD_MID = "</b>";
+    public static final String LIGHT_BOLD_END = "</p>";
+    public static final String EMPTY = " ";
+    public static final String LINE_BREAK = "\n";
+
+    private PrettyPrintHelper() {
+        throw new UnsupportedOperationException("Cannot instantiate this interface!");
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/common/alert/mail/handler/MailHandler.java
+++ b/src/main/java/io/dev/jobprep/common/alert/mail/handler/MailHandler.java
@@ -1,0 +1,115 @@
+package io.dev.jobprep.common.alert.mail.handler;
+
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.BOLD_END;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.BOLD_STRT;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.EMPTY;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.LIGHT_BOLD_END;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.LIGHT_BOLD_MID;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.LIGHT_BOLD_STRT;
+import static io.dev.jobprep.common.alert.mail.PrettyPrintHelper.LINE_BREAK;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MailHandler {
+
+    private static final Integer MAX_RETRY_ATTEMTPS = 5;
+    private static final String TOPIC = "Scheduler Task Retry Failure Notification";
+    private static final String RECOMMEND_MSG = "Please restart the scheduler or check the server logs!";
+    private static final String SUBJECT = "Scheduling Task Retry Failure Notification: %s";
+
+    @Value("${spring.mail.username}")
+    private String RECIPIENT;
+
+    @Value("${app.version}")
+    private String appVersion;
+
+    private final JavaMailSender mailSender;
+
+    public void postProcessEmailWithErr(String jobScheduler, Exception e) {
+
+        String subject = String.format(SUBJECT, jobScheduler);
+
+        // message Processing...
+        String content = generateEmailContent(jobScheduler, e);
+
+        try {
+            sendMail(subject, content);
+            log.info("send alert mail successfully to administraction!");
+        } catch (MessagingException | MailException e_) {
+            log.warn("Failed to send mail for Scheduler Err Notification: {}", e_.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private String generateEmailContent(String jobScheduler, Exception e) {
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(makeBold(TOPIC));
+        builder.append(makeLightBold("Job Name:", jobScheduler));
+        builder.append(makeLightBold("Failure Point:", LocalDateTime.now().toString()));
+        builder.append(makeLightBold("Error Msg:", e.getMessage()));
+        builder.append(makeLightBold("Exception Type:" , e.getClass().getName()));
+        builder.append(makeLightBold("StackTrace:", parse(e)));
+        builder.append(makeLightBold("Retry Attempts:", MAX_RETRY_ATTEMTPS.toString()));
+        builder.append(makeLightBold("Host:", getHostInfo()));
+        builder.append(makeLightBold("App Version:", appVersion));
+        builder.append(makeLightBold("Next Scheduled Attempt:", calculateNextScheduledAttemps().toString()));
+        builder.append(makeLightBold("Recommended Follow-up Action:", RECOMMEND_MSG));
+        return builder.toString();
+    }
+
+    private String parse(Exception e) {
+        StringWriter writer = new StringWriter();
+        e.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
+    }
+
+    private String getHostInfo() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            return "Unknown Host";
+        }
+    }
+
+    private LocalDateTime calculateNextScheduledAttemps() {
+        LocalDateTime today = LocalDateTime.now();
+        return today.plusDays(1).toLocalDate().atTime(LocalTime.MIDNIGHT);
+    }
+
+    private String makeBold(String message) {
+        return BOLD_STRT + message + BOLD_END + LINE_BREAK;
+    }
+
+    private String makeLightBold(String key, String value) {
+        return LIGHT_BOLD_STRT + key + LIGHT_BOLD_MID + EMPTY + value + LIGHT_BOLD_END + LINE_BREAK;
+    }
+
+    private void sendMail(String subject, String content) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(RECIPIENT);
+        helper.setSubject(subject);
+        helper.setText(content, true);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/io/dev/jobprep/common/swagger/template/StudySwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/StudySwagger.java
@@ -43,7 +43,8 @@ public interface StudySwagger {
                 schema = @Schema(implementation = ErrorResponse.class),
                 examples = {
                     @ExampleObject(name = "E00-STUDY-001", value = SwaggerStudyErrorExamples.DUPLICATE_STUDY_NAME),
-                    @ExampleObject(name = "E01-STUDY-001", value = SwaggerStudyErrorExamples.ALREADY_CREATED_STUDY)
+                    @ExampleObject(name = "E01-STUDY-001", value = SwaggerStudyErrorExamples.ALREADY_CREATED_STUDY),
+                    @ExampleObject(name = "E00-STUDY-002", value = SwaggerStudyErrorExamples.INVALID_START_DATE)
                 }
             )),
         @ApiResponse(responseCode = "403", description = "스터디를 생성할 권한이 없음",
@@ -162,6 +163,8 @@ public interface StudySwagger {
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class),
                 examples = {
+                    @ExampleObject(name = "E00-STUDY-002", value = SwaggerStudyErrorExamples.IMPOSSIBLE_TO_MODIFY_DATE_EARLIER),
+                    @ExampleObject(name = "E00-STUDY-003", value = SwaggerStudyErrorExamples.IMPOSSIBLE_TO_MODIFY_FIRST_WEEK),
                     @ExampleObject(name = "E01-STUDY-004", value = SwaggerStudyErrorExamples.ALREADY_FINISHED_STUDY),
                     @ExampleObject(name = "E01-STUDY-005", value = SwaggerStudyErrorExamples.ALREADY_DELETED_STUDY)
                 }

--- a/src/main/java/io/dev/jobprep/core/configuration/MailConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/MailConfig.java
@@ -1,0 +1,54 @@
+package io.dev.jobprep.core.configuration;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String HOST;
+
+    @Value("${spring.mail.port}")
+    private int PORT;
+
+    @Value("${spring.mail.username}")
+    private String USERNAME;
+
+    @Value("${spring.mail.password}")
+    private String PASSWORD;
+
+    @Value("${spring.mail.properties.mail.transport.protocol}")
+    private String TRANSPORT_PROTOCOL;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private String SMTP_AUTH;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private String SMTP_STARTTLS_ENABLE;
+
+    @Value("${spring.mail.properties.mail.debug}")
+    private String DEBUG;
+
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(HOST);
+        mailSender.setPort(PORT);
+        mailSender.setUsername(USERNAME);
+        mailSender.setPassword(PASSWORD);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", TRANSPORT_PROTOCOL);
+        props.put("mail.smtp.auth", SMTP_AUTH);
+        props.put("mail.smtp.starttls.enable", SMTP_STARTTLS_ENABLE);
+        props.put("mail.debug", DEBUG);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/io/dev/jobprep/core/configuration/RetryConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/RetryConfig.java
@@ -1,0 +1,10 @@
+package io.dev.jobprep.core.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+}

--- a/src/main/java/io/dev/jobprep/core/configuration/WebMvcConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package io.dev.jobprep.core.configuration;
+
+import io.dev.jobprep.system.internal.interceptor.IpWhiteListInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final IpWhiteListInterceptor ipWhiteListInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(ipWhiteListInterceptor)
+            .addPathPatterns("/internal/**")
+            .excludePathPatterns("/api/**", "/login/**");
+    }
+}

--- a/src/main/java/io/dev/jobprep/core/properties/swagger/error/SwaggerStudyErrorExamples.java
+++ b/src/main/java/io/dev/jobprep/core/properties/swagger/error/SwaggerStudyErrorExamples.java
@@ -3,6 +3,8 @@ package io.dev.jobprep.core.properties.swagger.error;
 public class SwaggerStudyErrorExamples {
 
     public static final String DUPLICATE_STUDY_NAME = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E00-STUDY-001\",\"message\":\"해당 스터디 이름이 이미 존재합니다.\"}";
+    public static final String INVALID_START_DATE = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E00-STUDY-002\",\"message\":\"스터디 시작 시간은 미래 시간이어야 합니다.\"}";
+    public static final String IMPOSSIBLE_TO_MODIFY_FIRST_WEEK = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E00-STUDY-003\",\"message\":\"스터디의 첫 주차는 변경할 수 없습니다.\"}";
     public static final String INVALID_STUDY_STATUS_TO_RECRUIT = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-001\",\"message\":\"스터디가 현재 모집중이 아닙니다.\"}";
     public static final String STUDY_WEEK_NUMBER_EXCEED = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-002\",\"message\":\"스터디는 3주 이상 진행할 수 없습니다.\"}";
     public static final String ALREADY_CREATED_STUDY = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-003\",\"message\":\"스터디는 한 번에 하나만 생성할 수 있습니다.\"}";
@@ -12,6 +14,7 @@ public class SwaggerStudyErrorExamples {
     public static final String ALREADY_GATHERED_STUDY = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-007\",\"message\":\"이미 참여 중인 스터디가 있습니다.\"}";
     public static final String ALREADY_PASSED_DUE_DATE = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-008\",\"message\":\"스터디의 모집 기간이 지났습니다.\"}";
     public static final String NON_GATHERED_USER = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E01-STUDY-011\",\"message\":\"해당 스터디에 유저가 존재하지 않습니다.\"}";
+    public static final String IMPOSSIBLE_TO_MODIFY_DATE_EARLIER = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"EE01-STUDY-012\",\"message\":\"스터디는 이전 주차보다 빠를 수 없습니다.\"}";
     public static final String STUDY_FORBIDDEN_OPERATION = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":403,\"code\":\"E02-STUDY-001\",\"message\":\"해당 작업에 대한 권한이 없습니다.\"}";
     public static final String STUDY_NOT_FOUND = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":404,\"code\":\"E03-STUDY-001\",\"message\":\"존재하지 않는 스터디입니다.\"}";
 }

--- a/src/main/java/io/dev/jobprep/domain/alert/application/AlertReportService.java
+++ b/src/main/java/io/dev/jobprep/domain/alert/application/AlertReportService.java
@@ -1,0 +1,19 @@
+package io.dev.jobprep.domain.alert.application;
+
+import io.dev.jobprep.domain.alert.slack.application.SlackAlertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlertReportService {
+
+    private final SlackAlertService slackAlertService;
+
+    @Transactional
+    public void report(String scheduler, Exception e) {
+        slackAlertService.sendAlertMsgToSlack(scheduler, e);
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/domain/alert/exception/AlertException.java
+++ b/src/main/java/io/dev/jobprep/domain/alert/exception/AlertException.java
@@ -1,0 +1,11 @@
+package io.dev.jobprep.domain.alert.exception;
+
+import io.dev.jobprep.exception.code.ErrorCode;
+import io.dev.jobprep.exception.exception_class.CustomException;
+
+public class AlertException extends CustomException {
+
+    public AlertException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/dev/jobprep/domain/alert/slack/application/SlackAlertService.java
+++ b/src/main/java/io/dev/jobprep/domain/alert/slack/application/SlackAlertService.java
@@ -1,0 +1,155 @@
+package io.dev.jobprep.domain.alert.slack.application;
+
+import static com.slack.api.model.block.Blocks.asBlocks;
+import static com.slack.api.model.block.Blocks.divider;
+import static com.slack.api.model.block.Blocks.header;
+import static com.slack.api.model.block.Blocks.section;
+import static io.dev.jobprep.exception.code.ErrorCode400.SLACK_ALERT_FAILURE;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.block.composition.MarkdownTextObject;
+import com.slack.api.model.block.composition.PlainTextObject;
+import com.slack.api.model.block.composition.TextObject;
+import io.dev.jobprep.domain.alert.exception.AlertException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackAlertService {
+
+    private static final Integer MAX_RETRY_ATTEMTPS = 5;
+    private static final String RECOMMEND_MSG = "Please Check server-log and Resolve err!";
+
+    @Value("${slack.bot-token}")
+    private String token;
+
+    @Value("${slack.channel.monitor}")
+    private String channel;
+
+    @Value("${app.version}")
+    private String appVersion;
+
+    /**
+     Slack 알림
+     - 작업 이름: 실패한 sql 파일명 예) delete_study_for_3_duration_weeks_after_12
+     - 실행 시간: 예) 2024.12.22T01:12:48.000Z
+     - 예외 메시지: 발생한 예외의 상세 메시지 예) java.net.ConnectException: Connection timed out.
+     - 예외 유형: 예외 클래스 이름 예) ConnectException
+     - 스택 트레이스: e.printStackTrace()
+     - 재시도 횟수: 5
+     - 호스트: Host: app-dev-server (34.47.100.172)
+     - 애플리케이션 버전: Version:
+     - 다음 작업 예상 시간: Next Scheduled Attempt: 2024-12-23T24:00:00
+     - 후속 작업 권장: Please restart the scheduler or check the server logs!
+     */
+
+    public void sendAlertMsgToSlack(
+        String scheduler,
+        Exception e
+    ) {
+
+        List<TextObject> objects = postProcess(scheduler, e);
+        MethodsClient methodClient = Slack.getInstance().methods(token);
+        ChatPostMessageRequest request = generateRequest(objects, e);
+
+        try {
+            methodClient.chatPostMessage(request);
+            log.info("send alert message successfully for slack channel {}", request.getChannel());
+        } catch (Exception e_) {
+            log.error("Failed to send message to Slack cause {} for exception {}", e_.getMessage(), e.getMessage());
+            throw new AlertException(SLACK_ALERT_FAILURE);
+        }
+    }
+
+    private List<TextObject> postProcess(String scheduler, Exception e) {
+        List<TextObject> objects = new ArrayList<>();
+        objects.add(MarkdownTextObject.builder().text("*Job Name:*\n" + scheduler).build());
+        objects.add(MarkdownTextObject.builder().text("*Failure Point:*\n" + LocalDateTime.now()).build());
+        objects.add(MarkdownTextObject.builder().text("*Error Msg:*\n" + e.getMessage()).build());
+        objects.add(MarkdownTextObject.builder().text("*Exception Type:*\n" + e.getClass().getName()).build());
+        objects.add(MarkdownTextObject.builder().text("*Recommended Follow-up Actions:*\n" + RECOMMEND_MSG).build());
+        return objects;
+    }
+
+    private ChatPostMessageRequest processRequest(List<TextObject> objects, Exception e) {
+        return ChatPostMessageRequest.builder()
+            .channel(channel)
+            .text(e.getMessage())
+            .blocks(asBlocks(
+                header(header -> header.text(PlainTextObject.builder().text("System Failure Report").build())),
+                divider(),
+                section(section -> section.fields(objects))
+            ))
+            .build();
+    }
+
+    @Deprecated
+    private List<TextObject> process(
+        String scheduler,
+        Exception e
+    ) {
+        List<TextObject> objects = new ArrayList<>();
+        objects.add(MarkdownTextObject.builder().text("*Job Name:*\n" + scheduler).build());
+        objects.add(MarkdownTextObject.builder().text("*Failure Point:*\n" + LocalDateTime.now()).build());
+        objects.add(MarkdownTextObject.builder().text("*Error Msg:*\n" + e.getMessage()).build());
+        objects.add(MarkdownTextObject.builder().text("*Exception Type:*\n" + e.getClass().getName()).build());
+        objects.add(MarkdownTextObject.builder().text("*StackTrace:*\n" + parse(e)).build());
+        objects.add(MarkdownTextObject.builder().text("*Retry Attempts:*\n" + MAX_RETRY_ATTEMTPS).build());
+        objects.add(MarkdownTextObject.builder().text("*Host:*\n" + getHostInfo()).build());
+        objects.add(MarkdownTextObject.builder().text("*App Version:*\n" + appVersion).build());
+        objects.add(MarkdownTextObject.builder().text("*Next Scheduled Attempt:*\n" + calculateNextScheduledAttemps()).build());
+        objects.add(MarkdownTextObject.builder().text("*Recommended Follow-up Actions:*\n" + RECOMMEND_MSG).build());
+        return objects;
+    }
+
+    @Deprecated
+    private String parse(Exception e) {
+        StringWriter writer = new StringWriter();
+        e.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
+    }
+
+    @Deprecated
+    private String getHostInfo() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            return "Unknown Host";
+        }
+    }
+
+    @Deprecated
+    private LocalDateTime calculateNextScheduledAttemps() {
+        LocalDateTime today = LocalDateTime.now();
+        return today.plusDays(1).toLocalDate().atTime(LocalTime.MIDNIGHT);
+    }
+
+    @Deprecated
+    private ChatPostMessageRequest generateRequest(List<TextObject> objects, Exception e) {
+        return ChatPostMessageRequest.builder()
+            .channel(channel)
+            .text(e.getMessage())
+            .blocks(asBlocks(
+                header(header -> header.text(PlainTextObject.builder().text("System Failure Report").build())),
+                divider(),
+                section(section -> section.fields(objects))
+            ))
+            .build();
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/domain/study/application/StudyCommonService.java
+++ b/src/main/java/io/dev/jobprep/domain/study/application/StudyCommonService.java
@@ -1,5 +1,10 @@
 package io.dev.jobprep.domain.study.application;
 
+import static io.dev.jobprep.exception.code.ErrorCode404.STUDY_NOT_FOUND;
+
+import io.dev.jobprep.domain.study.domain.entity.Study;
+import io.dev.jobprep.domain.study.exception.StudyException;
+import io.dev.jobprep.domain.study.infrastructure.StudyJpaRepository;
 import io.dev.jobprep.domain.study.infrastructure.UserStudyJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StudyCommonService {
 
+    private final StudyJpaRepository studyRepository;
     private final UserStudyJpaRepository userStudyRepository;
 
     public boolean isParticipator(Long studyId, Long userId) {
         return userStudyRepository.findByUserIdAndStudyId(studyId, userId).isPresent();
+    }
+
+    public Study getStudyWithId(Long studyId) {
+        return studyRepository.findById(studyId)
+            .orElseThrow(() -> new StudyException(STUDY_NOT_FOUND));
     }
 
 }

--- a/src/main/java/io/dev/jobprep/domain/study/application/StudyScheduleService.java
+++ b/src/main/java/io/dev/jobprep/domain/study/application/StudyScheduleService.java
@@ -1,7 +1,7 @@
 package io.dev.jobprep.domain.study.application;
 
-import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_DATE;
-import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_FIRST_DATE;
+import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_DATE_EARLIER;
+import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_FIRST_WEEK;
 import static io.dev.jobprep.exception.code.ErrorCode403.STUDY_FORBIDDEN_OPERATION;
 
 import io.dev.jobprep.domain.study.domain.entity.Study;
@@ -79,14 +79,14 @@ public class StudyScheduleService {
     private void validateDate(Long studyId, StudyUpdateRequest req) {
 
         if (req.getWeekNumber() == FIRST_WEEK) {
-            throw new StudyException(IMPOSSIBLE_TO_MODIFY_FIRST_DATE);
+            throw new StudyException(IMPOSSIBLE_TO_MODIFY_FIRST_WEEK);
         } else {
             StudySchedule previous = getStudySchedule(studyId, req.getWeekNumber() - 1);
             LocalDate previousDate = previous.getStart_date().toLocalDate();
             LocalDate modifiedDate = req.getStartDate().toLocalDate();
 
             if (modifiedDate.isBefore(previousDate) || modifiedDate.isEqual(previousDate)) {
-                throw new StudyException(IMPOSSIBLE_TO_MODIFY_DATE);
+                throw new StudyException(IMPOSSIBLE_TO_MODIFY_DATE_EARLIER);
             }
         }
     }

--- a/src/main/java/io/dev/jobprep/domain/study/domain/entity/StudySchedule.java
+++ b/src/main/java/io/dev/jobprep/domain/study/domain/entity/StudySchedule.java
@@ -1,5 +1,6 @@
 package io.dev.jobprep.domain.study.domain.entity;
 
+import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_FIRST_DATE;
 import static io.dev.jobprep.exception.code.ErrorCode400.STUDY_WEEK_NUMBER_EXCEED;
 import static io.dev.jobprep.exception.code.ErrorCode404.STUDY_NOT_FOUND;
 
@@ -58,7 +59,7 @@ public class StudySchedule {
     }
 
     public void modify(LocalDateTime startDate) {
-        validateDate(startDate, week_number);
+        validateDate();
         this.start_date = startDate;
     }
 
@@ -83,8 +84,11 @@ public class StudySchedule {
         return false;
     }
 
-    private void validateDate(LocalDateTime startDate, int weekNumber) {
+    private void validateDate() {
         // TODO: 이전 주차보다 큰 값인지, 다음 주차보다 작은 값인지 검증
         // 비즈니스 로직 vs 어노테이션 고민
+        if (week_number == MIN_WEEK_NUMBER) {
+            throw new StudyException(IMPOSSIBLE_TO_MODIFY_FIRST_DATE);
+        }
     }
 }

--- a/src/main/java/io/dev/jobprep/domain/study/domain/entity/StudySchedule.java
+++ b/src/main/java/io/dev/jobprep/domain/study/domain/entity/StudySchedule.java
@@ -1,6 +1,6 @@
 package io.dev.jobprep.domain.study.domain.entity;
 
-import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_FIRST_DATE;
+import static io.dev.jobprep.exception.code.ErrorCode400.IMPOSSIBLE_TO_MODIFY_FIRST_WEEK;
 import static io.dev.jobprep.exception.code.ErrorCode400.STUDY_WEEK_NUMBER_EXCEED;
 import static io.dev.jobprep.exception.code.ErrorCode404.STUDY_NOT_FOUND;
 
@@ -51,7 +51,6 @@ public class StudySchedule {
     private StudySchedule(Long id, Study study, LocalDateTime start_date, int week_number) {
         this.id = id;
         this.study = study;
-        // TODO: 주차별 시작 일자가 순차적으로 커지는지를 검증해야 할까?
         this.start_date = start_date;
         this.week_number = week_number;
         validateStudy(study);
@@ -88,7 +87,7 @@ public class StudySchedule {
         // TODO: 이전 주차보다 큰 값인지, 다음 주차보다 작은 값인지 검증
         // 비즈니스 로직 vs 어노테이션 고민
         if (week_number == MIN_WEEK_NUMBER) {
-            throw new StudyException(IMPOSSIBLE_TO_MODIFY_FIRST_DATE);
+            throw new StudyException(IMPOSSIBLE_TO_MODIFY_FIRST_WEEK);
         }
     }
 }

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
@@ -20,10 +20,10 @@ public interface StudyJpaRepository extends JpaRepository<Study, Long>, StudyRep
     @Query("select std from Study std where std.name = :name")
     Optional<Study> findStudyByName(String name);
 
-    @Query("""
-        select std from Study std join UserStudy us on std.id = us.study.id
-        where us.user.id = :userId and not std.status in ('FINISHED') or std.deletedAt = null
-    """)
+    @Query(value = """
+        select * from study as s inner join user_study us on s.id = us.study_id
+        where us.user_id = :userId and (not s.study_status = 'FINISHED' or s.deleted_at is not null)
+    """, nativeQuery = true)
     Optional<Study> findGatheredStudyByUserId(Long userId);
 
     @Query(value = """

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
@@ -22,7 +22,7 @@ public interface StudyJpaRepository extends JpaRepository<Study, Long>, StudyRep
 
     @Query("""
         select std from Study std join UserStudy us on std.id = us.study.id
-        where us.user.id = :userId and not std.status in ('FINISHED') and std.deletedAt = null
+        where us.user.id = :userId and not std.status in ('FINISHED') or std.deletedAt = null
     """)
     Optional<Study> findGatheredStudyByUserId(Long userId);
 

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -20,8 +20,11 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_POSITION_ARG("E01-STUDY-009", "스터디 직무 입력이 잘못되었습니다."),
     INVALID_STATUS_ARG("E01-STUDY-010", "스터디 상태가 잘못되었습니다."),
     NON_GATHERED_USER("E01-STUDY-011", "해당 스터디에 유저가 존재하지 않습니다."),
+    IMPOSSIBLE_TO_MODIFY_DATE("E01-STUDY-012", "스터디는 이전 주차보다 빠를 수 없습니다."),
     DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
     INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),
+    IMPOSSIBLE_TO_MODIFY_FIRST_DATE("E00-STUDY-003", "스터디의 첫 주차는 변경할 수 없습니다."),
+
 
     USER_ACCOUNT_ALREADY_EXISTS("E01-USER-001", "해당 이메일로 가입된 계정이 이미 존재합니다."),
     ALREADY_PENALIZED_USER("E01-USER-002", "이미 페널티가 부여된 유저입니다."),

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -9,6 +9,9 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_INPUT_VALUE("E00-COMMON-002", "기본 유효성 검사에 실패하였습니다."),
     ILLEGAL_INPUT_ARG("E00-COMMON-03", "유효하지 않은 입력 값입니다."),
 
+    DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
+    INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),
+    IMPOSSIBLE_TO_MODIFY_FIRST_WEEK("E00-STUDY-003", "스터디의 첫 주차는 변경할 수 없습니다."),
     INVALID_STUDY_STATUS_TO_RECRUIT("E01-STUDY-001", "스터디가 현재 모집중이 아닙니다."),
     STUDY_WEEK_NUMBER_EXCEED("E01-STUDY-002", "스터디는 3주 이상 진행할 수 없습니다."),
     ALREADY_CREATED_STUDY("E01-STUDY-003", "스터디는 한 번에 하나만 생성할 수 있습니다."),
@@ -21,9 +24,6 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_STATUS_ARG("E01-STUDY-010", "스터디 상태가 잘못되었습니다."),
     NON_GATHERED_USER("E01-STUDY-011", "해당 스터디에 유저가 존재하지 않습니다."),
     IMPOSSIBLE_TO_MODIFY_DATE_EARLIER("E01-STUDY-012", "스터디는 이전 주차보다 빠를 수 없습니다."),
-    DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
-    INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),
-    IMPOSSIBLE_TO_MODIFY_FIRST_WEEK("E00-STUDY-003", "스터디의 첫 주차는 변경할 수 없습니다."),
 
     USER_ACCOUNT_ALREADY_EXISTS("E01-USER-001", "해당 이메일로 가입된 계정이 이미 존재합니다."),
     ALREADY_PENALIZED_USER("E01-USER-002", "이미 페널티가 부여된 유저입니다."),

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -20,11 +20,10 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_POSITION_ARG("E01-STUDY-009", "스터디 직무 입력이 잘못되었습니다."),
     INVALID_STATUS_ARG("E01-STUDY-010", "스터디 상태가 잘못되었습니다."),
     NON_GATHERED_USER("E01-STUDY-011", "해당 스터디에 유저가 존재하지 않습니다."),
-    IMPOSSIBLE_TO_MODIFY_DATE("E01-STUDY-012", "스터디는 이전 주차보다 빠를 수 없습니다."),
+    IMPOSSIBLE_TO_MODIFY_DATE_EARLIER("E01-STUDY-012", "스터디는 이전 주차보다 빠를 수 없습니다."),
     DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
     INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),
-    IMPOSSIBLE_TO_MODIFY_FIRST_DATE("E00-STUDY-003", "스터디의 첫 주차는 변경할 수 없습니다."),
-
+    IMPOSSIBLE_TO_MODIFY_FIRST_WEEK("E00-STUDY-003", "스터디의 첫 주차는 변경할 수 없습니다."),
 
     USER_ACCOUNT_ALREADY_EXISTS("E01-USER-001", "해당 이메일로 가입된 계정이 이미 존재합니다."),
     ALREADY_PENALIZED_USER("E01-USER-002", "이미 페널티가 부여된 유저입니다."),

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -43,6 +43,8 @@ public enum ErrorCode400 implements ErrorCode {
     CHAT_ROOM_DISABLED("E01-CHATROOM-001", "해당 채팅방은 비활성화되었습니다."),
     NON_GATHERED_CHAT_USER("E01-CHATROOM-002", "해당 채팅방의 참여자가 아닙니다."),
     CHAT_ROOM_ALREADY_EXIST("E01-CHATROOM-003", "이미 생성된 채팅방이 있습니다."),
+
+    SLACK_ALERT_FAILURE("E00-ALERT-001", "슬랙 채널로 메시지 전송에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode401.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode401.java
@@ -9,6 +9,8 @@ public enum ErrorCode401 implements ErrorCode {
     AUTH_MISSING_CREDENTIALS("E02-AUTH-001", "사용자의 인증 정보를 찾을 수 없습니다."),
     AUTH_TOKEN_EXPIRED("E02-AUTH-002", "토큰이 만료되었습니다."),
 
+    INTERNAL_AUTH_MISSING_CREDENTIALS("E02-INTERNAL-001", "내부 관리자의 인증 정보를 찾을 수 없습니다."),
+
     USER_ACCOUNT_DISABLED("E01-USER-001", "탈퇴한 유저입니다")
     ;
 

--- a/src/main/java/io/dev/jobprep/scheduler/StudyAutoDeletionScheduler.java
+++ b/src/main/java/io/dev/jobprep/scheduler/StudyAutoDeletionScheduler.java
@@ -1,0 +1,150 @@
+package io.dev.jobprep.scheduler;
+
+import io.dev.jobprep.common.alert.mail.handler.MailHandler;
+import io.dev.jobprep.domain.alert.application.AlertReportService;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLTimeoutException;
+import java.util.stream.Collectors;
+import javax.naming.CommunicationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.lookup.DataSourceLookupFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class StudyAutoDeletionScheduler {
+
+    private static final String EMPTY = "";
+    private static final String LINE_BREAK = "\n";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Resource[] sqlStatements;
+    private final AlertReportService alertReportService;
+    private final MailHandler mailHandler;
+
+    protected StudyAutoDeletionScheduler(
+        JdbcTemplate jdbcTemplate,
+        @Qualifier("webApplicationContext") ResourcePatternResolver resourcePatternResolver,
+        @Value("${path.schedule.sql}") String sqlStatementsPath,
+        AlertReportService alertReportService,
+        MailHandler mailHandler
+    ) throws IOException {
+        this.jdbcTemplate = jdbcTemplate;
+        this.sqlStatements = resourcePatternResolver.getResources(sqlStatementsPath);
+        this.alertReportService = alertReportService;
+        this.mailHandler = mailHandler;
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    @Transactional(rollbackFor = {DataAccessException.class, Exception.class})
+    @Retryable(
+        retryFor = {
+            DataAccessResourceFailureException.class, QueryTimeoutException.class,
+            CannotGetJdbcConnectionException.class, SQLTimeoutException.class,
+            CommunicationException.class, DataSourceLookupFailureException.class
+        },
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
+    public void executeSqlFile() {
+        for (Resource statement : sqlStatements) {
+            execute(statement);
+        }
+    }
+
+    @Transactional(rollbackFor = {DataAccessException.class, Exception.class})
+    public void execute(Resource statement) {
+        String sql = loadSqlFromFile(statement);
+        try {
+            jdbcTemplate.execute(sql);
+        } catch (DataAccessResourceFailureException | QueryTimeoutException |
+                 DataSourceLookupFailureException e) {
+            // do-nothing cause auto-retry!
+        } catch (DataAccessException e) {
+            log.warn("Failed to executing Sql query cause {} for resource {}",
+                e.getMessage(), statement.getFilename());
+            report(statement.getFilename(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Execution of sql query failed due to an unexpected error {} for resource {}",
+                e.getMessage(), statement.getFilename());
+            report(statement.getFilename(), e);
+            throw e;
+        }
+    }
+
+    @Recover
+    public void fallbackMethod(Exception e) {
+        String scheduler = "STUDY-AUTO-DELETION SCHEDULER";
+        log.error("sql 스케줄링 실행 과정에서 오류 발생 : " + scheduler, e);
+        report(scheduler, e);
+    }
+
+    private String loadSqlFromFile(Resource resource) {
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8)
+        )) {
+            return reader.lines().collect(Collectors.joining(LINE_BREAK));
+        } catch (IOException e) {
+            log.error("sql 스케줄링 파일 로드 과정에서 오류 발생 : " + resource.getFilename(), e);
+            report(resource.getFilename(), e);
+            return EMPTY;
+        }
+    }
+
+    private void report(String job, Exception e) {
+        alertReportService.report(job, e);
+        mailHandler.postProcessEmailWithErr(job, e);
+    }
+
+    @Deprecated
+    @Transactional
+    public void deleteStudyForShortOnMember() {
+        jdbcTemplate.execute(
+            """
+            UPDATE study SET study_status = 'RECRUITMENT_CLOSED' and deleted_at = CURRENT_TIMESTAMP
+            WHERE id IN (
+                SELECT id FROM study
+                INNER JOIN user_study us on study.id = us.study_id
+                INNER JOIN study_schedule ss on study.id = ss.study_id
+                WHERE DATE(ss.start_date) = CURDATE() and ss.week_number = 1
+                HAVING COUNT(DISTINCT us.id) < study.head_count
+            )
+            """
+        );
+    }
+
+    @Deprecated
+    @Transactional
+    public void deleteStudyForCompletion() {
+        jdbcTemplate.execute(
+            """
+            UPDATE study SET study_status = 'FINISHED' and deleted_at = CURRENT_TIMESTAMP
+            WHERE id IN (
+                SELECT id FROM study
+                INNER JOIN study_schedule ss on study.id = ss.study_id
+                WHERE DATE_ADD(ss.start_date, INTERVAL 1 DAY) = CURDATE() and ss.week_number = duration_weeks
+            )
+            """
+        );
+    }
+
+
+}

--- a/src/main/java/io/dev/jobprep/system/internal/developer/DeveloperTokenHelper.java
+++ b/src/main/java/io/dev/jobprep/system/internal/developer/DeveloperTokenHelper.java
@@ -1,0 +1,39 @@
+package io.dev.jobprep.system.internal.developer;
+
+import io.dev.jobprep.system.internal.developer.token.DevToken;
+import io.dev.jobprep.system.internal.exception.InternalException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+import static io.dev.jobprep.exception.code.ErrorCode401.INTERNAL_AUTH_MISSING_CREDENTIALS;
+
+@Slf4j
+@Component
+public class DeveloperTokenHelper {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    @Value("${developer.token}")
+    private String token;
+
+    public void verify(String token) {
+        if (token == null || token.isBlank()) {
+            log.warn("Invalid Developer-token type at {}", LocalDateTime.now());
+            throw new InternalException(INTERNAL_AUTH_MISSING_CREDENTIALS);
+        }
+
+        if (!token.startsWith(TOKEN_PREFIX)) {
+            log.warn("Invalid Developer-token type at {}", LocalDateTime.now());
+            throw new InternalException(INTERNAL_AUTH_MISSING_CREDENTIALS);
+        }
+
+        DevToken devToken = DevToken.of(token);
+        if (!devToken.verify(this.token)) {
+            log.warn("Developer-token verification failed at {}", LocalDateTime.now());
+            throw new InternalException(INTERNAL_AUTH_MISSING_CREDENTIALS);
+        }
+    }
+}

--- a/src/main/java/io/dev/jobprep/system/internal/developer/token/DevToken.java
+++ b/src/main/java/io/dev/jobprep/system/internal/developer/token/DevToken.java
@@ -1,0 +1,24 @@
+package io.dev.jobprep.system.internal.developer.token;
+
+import lombok.Getter;
+
+@Getter
+public class DevToken {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private final String token;
+
+    private DevToken(final String token) {
+        this.token = token;
+    }
+
+    public static DevToken of(String token) {
+        token = token.substring(TOKEN_PREFIX.length());
+        return new DevToken(token);
+    }
+
+    public boolean verify(String token) {
+        return this.token.equals(token);
+    }
+}

--- a/src/main/java/io/dev/jobprep/system/internal/exception/InternalException.java
+++ b/src/main/java/io/dev/jobprep/system/internal/exception/InternalException.java
@@ -1,0 +1,11 @@
+package io.dev.jobprep.system.internal.exception;
+
+import io.dev.jobprep.exception.code.ErrorCode;
+import io.dev.jobprep.exception.exception_class.CustomException;
+
+public class InternalException extends CustomException {
+
+    public InternalException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
+++ b/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 @Slf4j
 @Component
@@ -36,17 +35,5 @@ public class IpWhiteListInterceptor implements HandlerInterceptor {
             return false;
         }
         return true;
-    }
-
-    @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-        ModelAndView modelAndView) throws Exception {
-        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
-        Object handler, Exception ex) throws Exception {
-        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
     }
 }

--- a/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
+++ b/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
@@ -1,0 +1,52 @@
+package io.dev.jobprep.system.internal.interceptor;
+
+import io.dev.jobprep.system.internal.whitelist.application.WhiteListManager;
+import io.dev.jobprep.util.IpAddressHelper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IpWhiteListInterceptor implements HandlerInterceptor {
+
+    private static final String LOCAL = "127.0.0.1";
+
+    private final WhiteListManager whiteListManager;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
+
+        String clientIp = IpAddressHelper.getClientIp(request);
+        log.info("Call internal API fron client with accessIp {}", clientIp);
+
+        if (clientIp.equals(LOCAL)) {
+            return true;
+        }
+
+        if (!whiteListManager.isBelongWhiteList(clientIp)) {
+            log.warn("Detect Non-allowed accessIp {} for URI {} access!", clientIp, request.getRequestURI());
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Non-allowed Ip-Address!");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+        ModelAndView modelAndView) throws Exception {
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+        Object handler, Exception ex) throws Exception {
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
+++ b/src/main/java/io/dev/jobprep/system/internal/interceptor/IpWhiteListInterceptor.java
@@ -23,7 +23,7 @@ public class IpWhiteListInterceptor implements HandlerInterceptor {
         Object handler) throws Exception {
 
         String clientIp = IpAddressHelper.getClientIp(request);
-        log.info("Call internal API fron client with accessIp {}", clientIp);
+        log.info("Call internal API from client with accessIp {}", clientIp);
 
         if (clientIp.equals(LOCAL)) {
             return true;

--- a/src/main/java/io/dev/jobprep/system/internal/presentation/SystemInternalController.java
+++ b/src/main/java/io/dev/jobprep/system/internal/presentation/SystemInternalController.java
@@ -2,12 +2,17 @@ package io.dev.jobprep.system.internal.presentation;
 
 import io.dev.jobprep.scheduler.StudyAutoDeletionScheduler;
 import java.time.LocalDateTime;
+
+import io.dev.jobprep.system.internal.developer.DeveloperTokenHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @RestController
@@ -16,9 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class SystemInternalController {
 
     private final StudyAutoDeletionScheduler scheduler;
+    private final DeveloperTokenHelper developerTokenHelper;
 
     @PatchMapping("/scheduler/re-run")
-    public ResponseEntity<Void> reRun() {
+    public ResponseEntity<Void> reRun(@RequestHeader(AUTHORIZATION) String token) {
+
+        // TODO: 추후에 Spring Security 와 합칠지 고민
+        developerTokenHelper.verify(token);
+
         log.info("re-run failed scheduler for STUDY-AUTO-DELETION at {}", LocalDateTime.now());
         scheduler.executeSqlFile();
         return ResponseEntity.ok().build();

--- a/src/main/java/io/dev/jobprep/system/internal/presentation/SystemInternalController.java
+++ b/src/main/java/io/dev/jobprep/system/internal/presentation/SystemInternalController.java
@@ -1,0 +1,27 @@
+package io.dev.jobprep.system.internal.presentation;
+
+import io.dev.jobprep.scheduler.StudyAutoDeletionScheduler;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/internal/api/v1")
+@RequiredArgsConstructor
+public class SystemInternalController {
+
+    private final StudyAutoDeletionScheduler scheduler;
+
+    @PatchMapping("/scheduler/re-run")
+    public ResponseEntity<Void> reRun() {
+        log.info("re-run failed scheduler for STUDY-AUTO-DELETION at {}", LocalDateTime.now());
+        scheduler.executeSqlFile();
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/system/internal/whitelist/application/WhiteListManager.java
+++ b/src/main/java/io/dev/jobprep/system/internal/whitelist/application/WhiteListManager.java
@@ -1,0 +1,22 @@
+package io.dev.jobprep.system.internal.whitelist.application;
+
+import io.dev.jobprep.system.internal.whitelist.infrastructure.WhiteListJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WhiteListManager {
+
+    private final WhiteListJpaRepository whiteListRepository;
+
+    public boolean isBelongWhiteList(String accessIp) {
+        return whiteListRepository.findByAccessIp(accessIp)
+            .isPresent();
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/system/internal/whitelist/domain/entity/WhiteList.java
+++ b/src/main/java/io/dev/jobprep/system/internal/whitelist/domain/entity/WhiteList.java
@@ -1,0 +1,45 @@
+package io.dev.jobprep.system.internal.whitelist.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "white_list")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WhiteList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "access_ip")
+    private String accessIp;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private WhiteList(Long id, String accessIp, LocalDateTime updatedAt) {
+        this.id = id;
+        this.accessIp = accessIp;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static WhiteList of(String accessIp) {
+        return WhiteList.builder()
+            .accessIp(accessIp)
+            .build();
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/system/internal/whitelist/infrastructure/WhiteListJpaRepository.java
+++ b/src/main/java/io/dev/jobprep/system/internal/whitelist/infrastructure/WhiteListJpaRepository.java
@@ -1,0 +1,15 @@
+package io.dev.jobprep.system.internal.whitelist.infrastructure;
+
+import io.dev.jobprep.system.internal.whitelist.domain.entity.WhiteList;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WhiteListJpaRepository extends JpaRepository<WhiteList, Long> {
+
+    @Query("select wl from WhiteList wl where wl.accessIp = :accessIp")
+    public Optional<WhiteList> findByAccessIp(String accessIp);
+
+}

--- a/src/main/java/io/dev/jobprep/util/IpAddressHelper.java
+++ b/src/main/java/io/dev/jobprep/util/IpAddressHelper.java
@@ -1,0 +1,45 @@
+package io.dev.jobprep.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class IpAddressHelper {
+
+    private static final String HEADER = "X-Forwarded-For";
+    private static final String UNKNOWN = "unknown";
+    private static final String LOCALHOST = "0:0:0:0:0:0:0:1";
+    private static final String LOCAL = "127.0.0.1";
+
+    private static final String[] IP_HEADER_CANDIDATES = {
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_X_FORWARDED_FOR",
+        "HTTP_X_FORWARDED",
+        "HTTP_X_CLUSTER_CLIENT_IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_FORWARDED_FOR",
+        "HTTP_FORWARDED",
+        "HTTP_VIA",
+        "REMOTE_ADDR"
+    };
+
+    public static String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader(HEADER);
+
+        for (String header : IP_HEADER_CANDIDATES) {
+            if (ip == null || ip.isEmpty() || UNKNOWN.equalsIgnoreCase(ip)) {
+                ip = request.getHeader(header);
+            }
+        }
+
+        if (ip == null || ip.isEmpty() || UNKNOWN.equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        if (ip.equals(LOCALHOST)) {
+            ip = LOCAL;
+        }
+
+        return ip;
+    }
+
+}

--- a/src/main/resources/db/migration/V20__ADD_WHITE_LIST.sql
+++ b/src/main/resources/db/migration/V20__ADD_WHITE_LIST.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS white_list (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    access_ip VARCHAR(20) NOT NULL,
+    active TINYINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP NULL
+);

--- a/src/main/resources/schedule_sql/delete_study_for_3_duration_weeks_after_12.sql
+++ b/src/main/resources/schedule_sql/delete_study_for_3_duration_weeks_after_12.sql
@@ -1,0 +1,6 @@
+UPDATE study SET study_status = 'FINISHED' and deleted_at = CURRENT_TIMESTAMP
+WHERE id IN (
+    SELECT id FROM study
+    INNER JOIN study_schedule ss on study.id = ss.study_id
+    WHERE DATE_ADD(ss.start_date, INTERVAL 1 DAY) = CURDATE() and ss.week_number = duration_weeks
+)

--- a/src/main/resources/schedule_sql/delete_study_for_short_on_member_after_12.sql
+++ b/src/main/resources/schedule_sql/delete_study_for_short_on_member_after_12.sql
@@ -1,0 +1,8 @@
+UPDATE study SET study.study_status = 'RECRUITMENT_CLOSED' and study.deleted_at = CURRENT_TIMESTAMP
+WHERE study.id IN (
+    SELECT study.id FROM study
+                       INNER JOIN user_study us on study.id = us.study_id
+                       INNER JOIN study_schedule ss on study.id = ss.study_id
+    WHERE DATE(ss.start_date) = CURDATE() and ss.week_number = 1
+    HAVING COUNT(DISTINCT us.id) < study.head_count
+)

--- a/src/main/resources/schedule_sql/study_in_progress_after_12.sql
+++ b/src/main/resources/schedule_sql/study_in_progress_after_12.sql
@@ -1,0 +1,8 @@
+UPDATE study SET study.study_status = 'IN_PROGRESS'
+WHERE study.id IN (
+    SELECT study.id FROM study
+                             INNER JOIN user_study us on study.id = us.study_id
+                             INNER JOIN study_schedule ss on study.id = ss.study_id
+    WHERE DATE(ss.start_date) = CURDATE() and ss.week_number = 1
+    HAVING COUNT(DISTINCT us.id) = study.head_count
+)


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 모집기간이 지난 스터디에 대한 상태 변경 스케줄링
- [x] 인원 미달 스터디에 대한 자동 삭제 스케줄링
- [x] 3주차 진행이 완료된 스터디에 대한 자동 삭제 스케줄링
- [x] 실패한 스케줄링 작업에 대한 Retry 로직 구현
- [x] 최종 실패한 작업에 대한 `Slack` `Mail` 을 활용한 알림 시스템 구현 
- [x] 실패한 작업에 대한 재실행을 위한 시스템 내부 internal API 구현   
- [x] internal API 호출 제한을 위한 IP white-list 관리 로직 구현  
- [x] 시스템 내부 `internal` API 호출 제한을 위한 dev-token 활용 로직 구현

### 이슈 번호
- close #186

## 특이 사항 🫶 
가감없이 피드백, 코멘트 남겨주세요! 환영합니다!
![image](https://github.com/user-attachments/assets/e2b9e6e4-e818-4b10-b9df-3f746de34a0c)
