### PR TITLE
Refact/#221 optimize offset based pagination

### DIFF
--- a/scripts/generate_dummy_data.py
+++ b/scripts/generate_dummy_data.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import random
+from faker import Faker
+
+# Faker 초기화
+fake = Faker()
+
+# 데이터 개수 설정
+num_records = 10_000_000  # 천만 개
+
+# ENUM 타입 필드 값 설정
+positions = ['상관없음', '개발', '디자인', '기획', '마케팅', '영업', '재무/회계', '인사']
+study_statuses = ['진행중', '모집중', '모집완료']
+
+# 랜덤 데이터 생성 함수
+def generate_data(num_records):
+    data = []
+    for i in range(1, num_records + 1):
+        study_name = f"Study_{i}"  # 고유한 study_name
+        position = random.choice(positions)
+        study_status = random.choice(study_statuses)
+        head_count = random.randint(1, 10)  # 1~10 사이 랜덤 값
+        duration_weeks = random.randint(1, 52)  # 1~52 사이 랜덤 값
+        google_link = fake.url() if random.random() > 0.5 else None
+        discord_link = fake.url() if random.random() > 0.5 else None
+        kakao_link = fake.url() if random.random() > 0.5 else None
+        created_at = fake.date_time_between(start_date="-5y", end_date="now")  # 최근 5년
+        deleted_at = (
+            fake.date_time_between(start_date=created_at, end_date="now")
+            if random.random() > 0.9
+            else None
+        )  # 일부 데이터만 삭제됨
+
+        data.append(
+            [
+                i,  # id
+                study_name,
+                position,
+                study_status,
+                head_count,
+                duration_weeks,
+                google_link,
+                discord_link,
+                kakao_link,
+                created_at,
+                deleted_at,
+            ]
+        )
+    return data
+
+# 데이터 생성 및 저장
+if __name__ == "__main__":
+    print("데이터 생성 중...")
+    column_names = [
+        "id",
+        "study_name",
+        "position",
+        "study_status",
+        "head_count",
+        "duration_weeks",
+        "google_link",
+        "discord_link",
+        "kakao_link",
+        "created_at",
+        "deleted_at",
+    ]
+
+    # 데이터를 생성하고 저장
+    batch_size = 1_000_000  # 메모리 문제를 방지하기 위한 배치 처리
+    for batch in range(num_records // batch_size):
+        print(f"{batch * batch_size} ~ {(batch + 1) * batch_size - 1} 데이터 생성 중...")
+        batch_data = generate_data(batch_size)
+        df = pd.DataFrame(batch_data, columns=column_names)
+
+        # CSV 저장 (추가 모드)
+        if batch == 0:
+            df.to_csv("study_data.csv", index=False, mode="w", encoding="utf-8-sig")
+        else:
+            df.to_csv("study_data.csv", index=False, mode="a", header=False, encoding="utf-8-sig")
+
+    print("CSV 파일 저장 완료: study_data.csv")

--- a/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
@@ -4,7 +4,6 @@ import io.dev.jobprep.common.base.CursorPaginationResult;
 import io.dev.jobprep.common.base.LongCursorPaginationReq;
 import io.dev.jobprep.core.properties.swagger.error.SwaggerApplicationStatusErrorExamples;
 import io.dev.jobprep.core.properties.swagger.error.SwaggerUserErrorExamples;
-import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusCreateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusUpdateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.res.ApplicationStatusCommonResponse;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.res.ApplicationStatusIdResponse;
@@ -37,8 +36,7 @@ public interface ApplicationStatusSwagger {
             ))
     })
     ResponseEntity<ApplicationStatusIdResponse> create(
-        @Parameter(description = "유저 ID", required = true) Long userId,
-        ApplicationStatusCreateRequest request
+        @Parameter(description = "유저 ID", required = true) Long userId
     );
 
     @Operation(summary = "지원 현황 삭제", description = "사용자가 지원현황을 삭제할 때 사용하는 API")

--- a/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
@@ -17,11 +17,14 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "Application Status", description = "지원 현황 관련 API")
+@SuppressWarnings("unused")
 public interface ApplicationStatusSwagger {
 
     @Operation(summary = "지원 현황 생성", description = "사용자가 지원현황을 추가할 때 사용하는 API")

--- a/src/main/java/io/dev/jobprep/common/swagger/template/ChatSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/ChatSwagger.java
@@ -16,11 +16,14 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "Chat", description = "채팅 관련 API")
+@SuppressWarnings("unused")
 public interface ChatSwagger {
 
     @Operation(summary = "채팅방 생성", description = "사용자가 첫 메시지를 보내기 전에 채팅방 생성을 위해 사용하는 API")

--- a/src/main/java/io/dev/jobprep/common/swagger/template/EssentialMaterialSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/EssentialMaterialSwagger.java
@@ -11,10 +11,13 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Tag(name = "Essential Material", description = "필수 자료 관련 API")
+@SuppressWarnings("unused")
 public interface EssentialMaterialSwagger {
     @Operation(summary = "필수 자료 열람", description = "사용자의 필수 자료를 열람할 때 사용하는 API")
     @ApiResponses(value = {

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/application/ApplicationStatusService.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/application/ApplicationStatusService.java
@@ -8,7 +8,6 @@ import io.dev.jobprep.domain.applicationstatus.domain.entity.ApplicationStatus;
 import io.dev.jobprep.domain.applicationstatus.domain.entity.InitData;
 import io.dev.jobprep.domain.applicationstatus.exception.ApplicationStatusException;
 import io.dev.jobprep.domain.applicationstatus.infrastructure.ApplicationStatusJpaRepository;
-import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusCreateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusUpdateRequest;
 import io.dev.jobprep.domain.users.domain.User;
 import io.dev.jobprep.domain.users.exception.UserException;
@@ -30,12 +29,12 @@ public class ApplicationStatusService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Long create(Long userId, ApplicationStatusCreateRequest req) {
+    public Long create(Long userId) {
 
         // TODO: 유저 토큰 검증
         User user = getUser(userId);
 
-        ApplicationStatus applicationStatus = req.toEntity(user);
+        ApplicationStatus applicationStatus = ApplicationStatus.ofEmpty(user);
         save(applicationStatus);
 
         return applicationStatus.getId();

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/ApplicationStatus.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/ApplicationStatus.java
@@ -129,4 +129,10 @@ public class ApplicationStatus {
             .coverLetter(coverLetter)
             .build();
     }
+
+    public static ApplicationStatus ofEmpty(User creator) {
+        return ApplicationStatus.builder()
+                .creator(creator)
+                .build();
+    }
 }

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/ApplicationStatusController.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/ApplicationStatusController.java
@@ -4,7 +4,6 @@ import io.dev.jobprep.common.base.CursorPaginationResult;
 import io.dev.jobprep.common.base.LongCursorPaginationReq;
 import io.dev.jobprep.common.swagger.template.ApplicationStatusSwagger;
 import io.dev.jobprep.domain.applicationstatus.application.ApplicationStatusService;
-import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusCreateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusUpdateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.res.ApplicationStatusCommonResponse;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.res.ApplicationStatusIdResponse;
@@ -33,11 +32,10 @@ public class ApplicationStatusController implements ApplicationStatusSwagger {
 
     @PostMapping
     public ResponseEntity<ApplicationStatusIdResponse> create(
-        @RequestParam Long userId,
-        @RequestBody ApplicationStatusCreateRequest request
+        @RequestParam Long userId
     ) {
         return ResponseEntity.status(201).body(
-            ApplicationStatusIdResponse.of(applicationStatusService.create(userId, request))
+            ApplicationStatusIdResponse.of(applicationStatusService.create(userId))
         );
     }
 

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/req/ApplicationStatusCreateRequest.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/req/ApplicationStatusCreateRequest.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Deprecated
 @Schema(description = "지원현황 생성 요청 Dto")
 @Getter
 @NoArgsConstructor

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusCommonResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusCommonResponse.java
@@ -5,7 +5,10 @@ import io.dev.jobprep.domain.applicationstatus.domain.entity.enums.ApplicationPr
 import io.dev.jobprep.domain.applicationstatus.domain.entity.enums.ApplicationProgress;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
+
 import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,7 +17,7 @@ import lombok.Getter;
 public class ApplicationStatusCommonResponse {
 
     @Schema(description = "지원 현황 ID", example = "2", implementation = Long.class)
-    @Nullable
+    @NotNull
     private final Long id;
 
     @Schema(description = "지원 기업", example = "애플", implementation = String.class)
@@ -64,12 +67,25 @@ public class ApplicationStatusCommonResponse {
         this.id = id;
         this.company = company;
         this.position = position;
-        this.progress = progress != null ? progress.getDescription() : null;
-        this.process = process != null ? process.getDescription() : null;
+        this.progress = resolve(progress);
+        this.process = resolve(process);
         this.applicationDate = applicationDate;
         this.dueDate = dueDate;
         this.url = url;
         this.coverLetter = coverLetter;
+    }
+
+    private String resolve(@Nullable final Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof ApplicationProgress) {
+            return ((ApplicationProgress) value).getDescription();
+        } else if (value instanceof ApplicationProcess) {
+            return ((ApplicationProcess) value).getDescription();
+        } else {
+            throw new UnsupportedOperationException("Unsupported value type: " + value.getClass());
+        }
     }
 
     public static ApplicationStatusCommonResponse from(ApplicationStatus applicationStatus) {

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusInfoResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/presentation/dto/res/ApplicationStatusInfoResponse.java
@@ -58,12 +58,25 @@ public class ApplicationStatusInfoResponse {
     ) {
         this.company = company;
         this.position = position;
-        this.progress = progress != null ? progress.getDescription() : null;
-        this.process = process != null ? process.getDescription() : null;
+        this.progress = resolve(progress);
+        this.process = resolve(process);
         this.applicationDate = applicationDate;
         this.dueDate = dueDate;
         this.url = url;
         this.coverLetter = coverLetter;
+    }
+
+    private String resolve(@Nullable final Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof ApplicationProgress) {
+            return ((ApplicationProgress) value).getDescription();
+        } else if (value instanceof ApplicationProcess) {
+            return ((ApplicationProcess) value).getDescription();
+        } else {
+            throw new UnsupportedOperationException("Unsupported value type: " + value.getClass());
+        }
     }
 
     public static ApplicationStatusInfoResponse from(ApplicationStatus applicationStatus) {

--- a/src/main/java/io/dev/jobprep/domain/study/application/StudyService.java
+++ b/src/main/java/io/dev/jobprep/domain/study/application/StudyService.java
@@ -122,8 +122,9 @@ public class StudyService {
         User user = getUser(userId);
 
         // TODO: User 엔티티 추가 시, 양뱡향 연관관계 매핑 후 수정
-        List<Study> studies = studyRepository
-            .findRecruitingStudyWithPagination(page, pageGroupSize, pageSize);
+        List<Study> studies = studyRepository.findRecruitingStudyWithPagination(
+            (page - 1) * pageSize, pageSize * pageGroupSize
+        );
         return studies.stream().map(
             (study) -> StudyInfoDto.of(
                     getStudyWithStartDate(study.getId()),

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
@@ -27,6 +27,18 @@ public interface StudyJpaRepository extends JpaRepository<Study, Long>, StudyRep
     Optional<Study> findGatheredStudyByUserId(Long userId);
 
     @Query(value = """
+        SELECT * FROM study AS std
+            JOIN (
+                    SELECT id FROM study
+                    WHERE study_status = 'RECRUITING' AND deleted_at IS NULL
+                    ORDER BY id DESC
+                    LIMIT :offset, :limit
+            ) AS temp USING (id)
+        ORDER BY std.id DESC
+    """, nativeQuery = true)
+    List<Study> findRecruitingStudyWithPagination(int offset, int limit);
+
+    @Query(value = """
         select * from study as s left join user_study us on s.id = us.study_id
         where s.study_status = 'RECRUITING' group by s.id having count(us.user_id) < :headCount
     """, nativeQuery = true)

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyJpaRepository.java
@@ -31,10 +31,8 @@ public interface StudyJpaRepository extends JpaRepository<Study, Long>, StudyRep
             JOIN (
                     SELECT id FROM study
                     WHERE study_status = 'RECRUITING' AND deleted_at IS NULL
-                    ORDER BY id DESC
                     LIMIT :offset, :limit
             ) AS temp USING (id)
-        ORDER BY std.id DESC
     """, nativeQuery = true)
     List<Study> findRecruitingStudyWithPagination(int offset, int limit);
 

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyRepositoryCustom.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyRepositoryCustom.java
@@ -8,8 +8,5 @@ import java.util.Optional;
 public interface StudyRepositoryCustom {
 
     Optional<StudyWithStartDateDto> getStudyWithStartDate(Long studyId);
-
     List<Study> findNonDeletedStudyWithPagination(Long cursorId, int pageSize);
-
-    List<Study> findRecruitingStudyWithPagination(int page, int pageSize, int pageGroupSize);
 }

--- a/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyRepositoryCustomImpl.java
+++ b/src/main/java/io/dev/jobprep/domain/study/infrastructure/StudyRepositoryCustomImpl.java
@@ -46,21 +46,6 @@ public class StudyRepositoryCustomImpl implements StudyRepositoryCustom {
             .fetch();
     }
 
-    @Override
-    public List<Study> findRecruitingStudyWithPagination(int page, int pageSize, int pageGroupSize) {
-        int offset = (page - 1) * pageSize;
-
-        return jpaQueryFactory.selectFrom(study)
-            .where(
-                studyStatusEq(StudyStatus.RECRUITING),
-                deletedAtEq()
-            )
-            .offset(offset)
-            .limit((long) pageSize * pageGroupSize)
-            .orderBy(study.id.desc())
-            .fetch();
-    }
-
     private BooleanExpression cursorIdCondition(Long cursorId) {
         return cursorId != null ? study.id.lt(cursorId) : null;
     }

--- a/src/main/resources/db/migration/V21__CHANGE_NULL_FOR_APPLICATION_STATUS.sql
+++ b/src/main/resources/db/migration/V21__CHANGE_NULL_FOR_APPLICATION_STATUS.sql
@@ -1,0 +1,5 @@
+ALTER TABLE application_status
+MODIFY application_progress ENUM ('NOT_STARTED', 'IN_PROGRESS', 'SUCCEED', 'FAILED') NULL;
+
+ALTER TABLE application_status
+MODIFY application_process ENUM ('DOCUMENT_SCREENING', 'APTITUDE_CODING_TEST', 'FIRST_INTERVIEW', 'FINAL_INTERVIEW') NULL;

--- a/src/main/resources/db/migration/V22__ADD_COVERING_INDEX_FOR_STUDY.sql
+++ b/src/main/resources/db/migration/V22__ADD_COVERING_INDEX_FOR_STUDY.sql
@@ -1,0 +1,2 @@
+CREATE INDEX study_id_study_status__index
+ON study (study_status desc, deleted_at asc, id desc);


### PR DESCRIPTION
## 🚀 개발 사항
- [x] `applicationStatus` 도메인의 create API에서 빈 값의 데이터를 생성하도록 수정
- [x] 빈 값에 대한 데이터 반환을 `null` 로 통일
- [x] 오프셋 기반 페이지네이션 성능 최적화 ( 더미 데이터 10,000,000건 기준으로, 조회 성능 약 6배 이상 향상 )


API 성능 테스트
![image](https://github.com/user-attachments/assets/f60f3edb-ff27-44aa-9fa7-9e2b091a7ddb)
 
쿼리 최적화하기 이전
![image](https://github.com/user-attachments/assets/0e225bb5-bc4f-4c51-a5f0-f96df820a6c2)

Deferred Join + Covering index를 이용한 쿼리 최적화 이후
![image](https://github.com/user-attachments/assets/7bd3c18a-0d09-4de5-aa77-84b57c69dc77)


### 이슈 번호
- close #221

## 특이 사항 🫶 
