### PR TITLE
Refact/#228 error handling for chat

### DIFF
--- a/src/main/java/io/dev/jobprep/common/stomp/StompTokenProcessor.java
+++ b/src/main/java/io/dev/jobprep/common/stomp/StompTokenProcessor.java
@@ -23,6 +23,7 @@ public class StompTokenProcessor {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String DESTINATION_HEADER = "Destination";
     private static final String DESTINATION_PREFIX = "/topic/";
+    private static final String TOPIC_PREFIX = "/app/";
     private static final String TEMP_AUTHORIZATION = "UserId";
 
     private final UserCommonService userCommonService;
@@ -62,10 +63,11 @@ public class StompTokenProcessor {
 
     private UUID verifyDestinationFromSubscription(StompHeaderAccessor stompHeaderAccessor) {
         String subscription = stompHeaderAccessor.getDestination();
-        if (subscription == null || !subscription.startsWith(DESTINATION_PREFIX)) {
+        log.info("Received subscription: {}", subscription);
+        if (subscription == null || !subscription.startsWith(TOPIC_PREFIX)) {
             throw new ChatException(CHAT_MISSING_DESTINATION);
         }
-        subscription = subscription.substring(DESTINATION_PREFIX.length());
+        subscription = subscription.substring(TOPIC_PREFIX.length());
         log.info("Received a subscription from {}", subscription);
         return UUID.fromString(subscription);
     }

--- a/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/ApplicationStatusSwagger.java
@@ -3,6 +3,7 @@ package io.dev.jobprep.common.swagger.template;
 import io.dev.jobprep.common.base.CursorPaginationResult;
 import io.dev.jobprep.common.base.LongCursorPaginationReq;
 import io.dev.jobprep.core.properties.swagger.error.SwaggerApplicationStatusErrorExamples;
+import io.dev.jobprep.core.properties.swagger.error.SwaggerCommonErrorExamples;
 import io.dev.jobprep.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusCreateRequest;
 import io.dev.jobprep.domain.applicationstatus.presentation.dto.req.ApplicationStatusUpdateRequest;
@@ -109,6 +110,12 @@ public interface ApplicationStatusSwagger {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "지원 현황 수정 성공",
             content = @Content(schema = @Schema(implementation = ApplicationStatusUpdateResponse.class))),
+        @ApiResponse(responseCode = "400", description = "데이터가 유효하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E00-COMMON-004", value = SwaggerCommonErrorExamples.UNSUPPORTED_FIELD_TYPE)
+            )),
         @ApiResponse(responseCode = "403", description = "데이터를 삭제할 권한이 없음",
             content = @Content(
                 mediaType = "application/json",

--- a/src/main/java/io/dev/jobprep/common/swagger/template/ChatSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/ChatSwagger.java
@@ -42,6 +42,19 @@ public interface ChatSwagger {
     })
     ResponseEntity<ChatRoomIdResponse> create(@Parameter(required = true) Long userId);
 
+    @Operation(summary = "채팅방 조회", description = "사용자가 메시지를 보내기 위해 채팅방이 존재하는지 확인할 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "채팅방 조회 성공",
+            content = @Content(schema = @Schema(implementation = ChatRoomIdResponse.class))),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E03-USER-001", value = SwaggerUserErrorExamples.USER_NOT_FOUND)
+            ))
+    })
+    ResponseEntity<ChatRoomIdResponse> getExistChatRoom(@Parameter(required = true) Long userId);
+
     @Operation(summary = "채팅 메시지 내역 조회", description = "사용자가 관리자와의 채팅 메시지 내역을 조회할 때 사용하는 API")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "채팅 메시지 내역 조회 성공"),

--- a/src/main/java/io/dev/jobprep/core/configuration/MongoConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/MongoConfig.java
@@ -1,6 +1,9 @@
 package io.dev.jobprep.core.configuration;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
 
 @Configuration
 public class MongoConfig {

--- a/src/main/java/io/dev/jobprep/core/properties/swagger/error/SwaggerCommonErrorExamples.java
+++ b/src/main/java/io/dev/jobprep/core/properties/swagger/error/SwaggerCommonErrorExamples.java
@@ -1,0 +1,7 @@
+package io.dev.jobprep.core.properties.swagger.error;
+
+public class SwaggerCommonErrorExamples {
+
+    public static final String UNSUPPORTED_FIELD_TYPE = "{\"timestamp\":\"2024-12-02T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E03-COMMON-004\",\"message\":\"지원하지 않는 필드 타입입니다.\"}";
+
+}

--- a/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/ApplicationStatus.java
+++ b/src/main/java/io/dev/jobprep/domain/applicationstatus/domain/entity/ApplicationStatus.java
@@ -1,7 +1,10 @@
 package io.dev.jobprep.domain.applicationstatus.domain.entity;
 
+import static io.dev.jobprep.exception.code.ErrorCode400.UNSUPPORTED_FIELD_TYPE;
+
 import io.dev.jobprep.domain.applicationstatus.domain.entity.enums.ApplicationProcess;
 import io.dev.jobprep.domain.applicationstatus.domain.entity.enums.ApplicationProgress;
+import io.dev.jobprep.domain.applicationstatus.exception.ApplicationStatusException;
 import io.dev.jobprep.domain.users.domain.User;
 import io.dev.jobprep.util.LocalDateTimeConverter;
 import jakarta.persistence.Column;
@@ -100,6 +103,7 @@ public class ApplicationStatus {
             case "dueDate" -> this.dueDate = LocalDateTimeConverter.convertToUtcLDT(newVal);
             case "url" -> this.url = newVal;
             case "coverLetter" -> this.coverLetter = newVal;
+            default -> throw new ApplicationStatusException(UNSUPPORTED_FIELD_TYPE);
         }
     }
 

--- a/src/main/java/io/dev/jobprep/domain/chat/application/ChatService.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/application/ChatService.java
@@ -75,7 +75,7 @@ public class ChatService {
 
         try {
             @Nullable ChatRoom chatRoom = getChatRoom(userId);
-            return getMessageHistoryForChatRoom(chatRoom, cursorId, pageSize);
+            return getMessageHistoryForChatRoom(chatRoom, userId, cursorId, pageSize);
         } catch (NullPointerException e) {
             return List.of(ChatMessageCommonInfo.of(null, null));
         }
@@ -91,7 +91,7 @@ public class ChatService {
         }
 
         ChatRoom chatRoom = getChatRoom(roomId);
-        return getMessageHistoryForChatRoom(chatRoom, cursorId, pageSize);
+        return getMessageHistoryForChatRoom(chatRoom, userId, cursorId, pageSize);
     }
 
     public void access(UUID roomId, Long userId, String sessionId) {
@@ -114,9 +114,9 @@ public class ChatService {
     }
 
     private List<ChatMessageCommonInfo> getMessageHistoryForChatRoom(
-        ChatRoom chatRoom, Long cursorId, int pageSize
+        ChatRoom chatRoom, Long userId, Long cursorId, int pageSize
     ) {
-        return getMessagesHistoryWithPagination(chatRoom.getId(), cursorId, pageSize)
+        return getMessagesHistoryWithPagination(chatRoom.getId(), userId, cursorId, pageSize)
                 .stream().map(
                         chatMessage -> ChatMessageCommonInfo.of(
                                 chatRoom,
@@ -135,8 +135,8 @@ public class ChatService {
         return chatRepository.findAllActiveRooms(userId, cursorId, pageSize);
     }
 
-    private List<ChatMessage> getMessagesHistoryWithPagination(UUID roomId, Long cursorId, int pageSize) {
-        return chatRepository.findAllMessageHistory(roomId, cursorId, pageSize);
+    private List<ChatMessage> getMessagesHistoryWithPagination(UUID roomId, Long userId, Long cursorId, int pageSize) {
+        return chatRepository.findAllMessageHistory(roomId, userId, cursorId, pageSize);
     }
 
     private boolean stillReadMore(ChatRoom chatRoom, Long userId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/application/ChatWSService.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/application/ChatWSService.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -26,6 +27,7 @@ public class ChatWSService {
     private final ChatRedisService redisService;
     private final SequenceGenerator generator;
 
+    @Transactional(value = "mongoTransactionManager")
     public ChatMessageCommonInfo handle(UUID roomId, Long userId, String message) {
 
         User user = userCommonService.getUserWithId(userId);
@@ -33,13 +35,18 @@ public class ChatWSService {
         chatRoom.isGathered(user);
         chatRoom.validateActive();
 
-        ChatMessage chat = handleChat(chatRoom, userId, message);
-        ChatRoom room = handleChatRoom(chatRoom, chat);
+        ChatMessage chatMessage = handleChat(chatRoom, userId, message);
+        try {
+            handleChatRoom(chatRoom, chatMessage);
+        } catch (RuntimeException e) {
+            // Unchecked Exception 발생 시, 예외의 상위 전파를 막아 트랜잭션 롤백을 방지
+            log.info("Error {} while handling chat message", e.getMessage());
+        }
 
-        return ChatMessageCommonInfo.of(room, chat);
+        return ChatMessageCommonInfo.of(chatRoom, chatMessage);
     }
 
-    @Transactional("mongoTransactionManager")
+    @Transactional(value = "mongoTransactionManager")
     public ChatMessage handleChat(ChatRoom chatRoom, Long userId, String message) {
 
         UUID roomId = chatRoom.getId();
@@ -63,20 +70,20 @@ public class ChatWSService {
         return chatRepository.save(chatMessage);
     }
 
-    @Transactional("mongoTransactionManager")
-    public ChatRoom handleChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
+    @Transactional(value = "mongoTransactionManager", propagation = Propagation.REQUIRES_NEW)
+    public void handleChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
         updateComplete(chatMessage);
-        return updateChatRoom(chatRoom, chatMessage);
+        updateChatRoom(chatRoom, chatMessage);
     }
 
     protected void updateComplete(ChatMessage chatMessage) {
         chatMessage.complete();
-        chatRepository.save(chatMessage);
+        chatRepository.update(chatMessage);
     }
 
-    protected ChatRoom updateChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
+    protected void updateChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
         chatRoom.updateLastMessage(chatMessage);
-        return chatRepository.save(chatRoom);
+        chatRepository.save(chatRoom);
     }
 
     protected void markAsRead(ChatMessage chatMessage, Long readerId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/application/ChatWSService.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/application/ChatWSService.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -32,6 +33,17 @@ public class ChatWSService {
         chatRoom.isGathered(user);
         chatRoom.validateActive();
 
+        ChatMessage chat = handleChat(chatRoom, userId, message);
+        ChatRoom room = handleChatRoom(chatRoom, chat);
+
+        return ChatMessageCommonInfo.of(room, chat);
+    }
+
+    @Transactional("mongoTransactionManager")
+    public ChatMessage handleChat(ChatRoom chatRoom, Long userId, String message) {
+
+        UUID roomId = chatRoom.getId();
+
         ChatMessage chatMessage = ChatMessage.of(
             generator.getNextSequence(roomId.toString()),
             roomId,
@@ -48,14 +60,26 @@ public class ChatWSService {
             markAsRead(chatMessage, oppositeId);
         }
 
-        chatRoom.updateLastMessage(chatMessage);
-        chatRepository.save(chatRoom);
-        chatRepository.save(chatMessage);
-
-        return ChatMessageCommonInfo.of(chatRoom, chatMessage);
+        return chatRepository.save(chatMessage);
     }
 
-    private void markAsRead(ChatMessage chatMessage, Long readerId) {
+    @Transactional("mongoTransactionManager")
+    public ChatRoom handleChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
+        updateComplete(chatMessage);
+        return updateChatRoom(chatRoom, chatMessage);
+    }
+
+    protected void updateComplete(ChatMessage chatMessage) {
+        chatMessage.complete();
+        chatRepository.save(chatMessage);
+    }
+
+    protected ChatRoom updateChatRoom(ChatRoom chatRoom, ChatMessage chatMessage) {
+        chatRoom.updateLastMessage(chatMessage);
+        return chatRepository.save(chatRoom);
+    }
+
+    protected void markAsRead(ChatMessage chatMessage, Long readerId) {
         chatMessage.addReader(readerId);
     }
 

--- a/src/main/java/io/dev/jobprep/domain/chat/application/dto/res/ChatMessageCommonInfo.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/application/dto/res/ChatMessageCommonInfo.java
@@ -4,6 +4,7 @@ import static io.dev.jobprep.exception.code.ErrorCode400.NON_GATHERED_CHAT_USER;
 
 import io.dev.jobprep.domain.chat.domain.entity.document.ChatMessage;
 import io.dev.jobprep.domain.chat.domain.entity.document.ChatRoom;
+import io.dev.jobprep.domain.chat.domain.entity.enums.Status;
 import io.dev.jobprep.domain.chat.exception.ChatException;
 import io.dev.jobprep.domain.users.application.dto.res.UserCommonInfo;
 import java.time.LocalDateTime;
@@ -19,6 +20,8 @@ public class ChatMessageCommonInfo {
 
     private final String message;
 
+    private final Status status;
+
     private final LocalDateTime createdAt;
 
     @Builder
@@ -26,23 +29,46 @@ public class ChatMessageCommonInfo {
         Long id,
         UserCommonInfo senderInfo,
         String message,
+        Status status,
         LocalDateTime createdAt
     ) {
         this.id = id;
         this.senderInfo = senderInfo;
         this.message = message;
+        this.status = status;
         this.createdAt = createdAt;
     }
 
     public static ChatMessageCommonInfo of(ChatRoom chatRoom, ChatMessage chatMessage) {
+
         return ChatMessageCommonInfo.builder()
-            .id(chatMessage != null ? chatMessage.getId() : null)
-            .senderInfo(chatMessage != null ?
-                UserCommonInfo.from(chatRoom.getUsers().get(getSenderIdx(chatRoom,
-                    chatMessage.getSenderId()))) : null)
-            .message(chatMessage != null ? chatMessage.getMessage() : null)
-            .createdAt(chatMessage != null ? chatMessage.getCreatedAt() : null)
+            .id((Long) resolve(chatMessage, Long.class))
+            .senderInfo(resolve(chatMessage, chatRoom))
+            .message((String) resolve(chatMessage, String.class))
+            .status((Status) resolve(chatMessage, Status.class))
+            .createdAt((LocalDateTime) resolve(chatMessage, LocalDateTime.class))
             .build();
+    }
+
+    private static Object resolve(ChatMessage chatMessage, Class<?> clazz) {
+        if (clazz == Long.class) {
+            return chatMessage != null ? chatMessage.getId() : null;
+        } else if (clazz == String.class) {
+            return chatMessage != null ? chatMessage.getMessage() : null;
+        } else if (clazz == Status.class) {
+            return chatMessage != null ? chatMessage.getStatus() : null;
+        } else if (clazz == LocalDateTime.class) {
+            return chatMessage != null ? chatMessage.getCreatedAt() : null;
+        } else {
+            throw new UnsupportedOperationException("invalid field type!");
+        }
+    }
+
+    private static UserCommonInfo resolve(ChatMessage chatMessage, ChatRoom chatRoom) {
+        return chatMessage != null ?
+            UserCommonInfo.from(
+                chatRoom.getUsers().get(getSenderIdx(chatRoom, chatMessage.getSenderId()))
+            ) : null;
     }
 
     private static Integer getSenderIdx(ChatRoom chatRoom, Long senderId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/domain/entity/document/ChatMessage.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/domain/entity/document/ChatMessage.java
@@ -1,5 +1,6 @@
 package io.dev.jobprep.domain.chat.domain.entity.document;
 
+import io.dev.jobprep.domain.chat.domain.entity.enums.Status;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,9 @@ public class ChatMessage {
     @Field("content")
     private String message;
 
+    @Field("status")
+    private Status status;
+
     @Field("timestamp")
     private LocalDateTime createdAt;
 
@@ -39,6 +43,7 @@ public class ChatMessage {
         this.roomId = roomId;
         this.senderId = senderId;
         this.message = message;
+        this.status = Status.WAITING;
         this.createdAt = LocalDateTime.now();
         this.readBy = new ArrayList<>();
     }
@@ -51,6 +56,11 @@ public class ChatMessage {
 
     public boolean validateAvailableRead(Long userId) {
         return !readBy.contains(userId);
+    }
+
+    public void complete() {
+        status.validateAvailableReSend();
+        this.status = Status.COMPLETE;
     }
 
     public static ChatMessage of(Long id, UUID roomId, Long senderId, String messasge) {

--- a/src/main/java/io/dev/jobprep/domain/chat/domain/entity/enums/Status.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/domain/entity/enums/Status.java
@@ -3,7 +3,9 @@ package io.dev.jobprep.domain.chat.domain.entity.enums;
 import static io.dev.jobprep.exception.code.ErrorCode400.ALREADY_COMPLETED_CHAT;
 
 import io.dev.jobprep.domain.chat.exception.ChatException;
+import lombok.Getter;
 
+@Getter
 public enum Status {
 
     WAITING("대기 상태"),

--- a/src/main/java/io/dev/jobprep/domain/chat/domain/entity/enums/Status.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/domain/entity/enums/Status.java
@@ -1,0 +1,25 @@
+package io.dev.jobprep.domain.chat.domain.entity.enums;
+
+import static io.dev.jobprep.exception.code.ErrorCode400.ALREADY_COMPLETED_CHAT;
+
+import io.dev.jobprep.domain.chat.exception.ChatException;
+
+public enum Status {
+
+    WAITING("대기 상태"),
+    COMPLETE("전송 완료"),
+    ;
+
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+
+    public void validateAvailableReSend() {
+        if (this == COMPLETE) {
+            throw new ChatException(ALREADY_COMPLETED_CHAT);
+        }
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
@@ -3,6 +3,7 @@ package io.dev.jobprep.domain.chat.infrastructure;
 import io.dev.jobprep.domain.chat.domain.entity.document.ChatMessage;
 import io.dev.jobprep.domain.chat.domain.entity.document.ChatRoom;
 import io.dev.jobprep.domain.chat.domain.entity.enums.ChatRoomStatus;
+import io.dev.jobprep.domain.chat.domain.entity.enums.Status;
 import io.dev.jobprep.util.LocalDateTimeConverter;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,10 +47,20 @@ public class ChatMongoRepository {
         return Optional.ofNullable(mongoTemplate.findOne(query, ChatRoom.class));
     }
 
+    public Optional<ChatRoom> findValidRoomByByUserId(Long userId) {
+        Query query = new Query();
+        query.addCriteria(verifyUserId(userId))
+             .addCriteria(verifyValid())
+             .addCriteria(verifyActive());
+        return Optional.ofNullable(mongoTemplate.findOne(query, ChatRoom.class));
+    }
+
     public List<ChatRoom> findAllActiveRooms(Long userId, String cursorId, int pageSize) {
         Query query = new Query();
         query.limit(pageSize + 1)
             .addCriteria(verifyUserId(userId))
+            .addCriteria(verifyValid())
+            .addCriteria(verifyActive())
             .with(Sort.by(Sort.Order.desc("last_message.timestamp")));
 
         if (!cursorId.isBlank()) {
@@ -59,10 +70,12 @@ public class ChatMongoRepository {
         return mongoTemplate.find(query, ChatRoom.class);
     }
 
-    public List<ChatMessage> findAllMessageHistory(UUID roomId, Long cursorId, int pageSize) {
+    public List<ChatMessage> findAllMessageHistory(UUID roomId, Long userId, Long cursorId, int pageSize) {
         Query query = new Query();
         query.limit(pageSize + 1)
              .addCriteria(verifyRoomId(roomId))
+             .addCriteria(verifyWaiting(userId))
+             .addCriteria(verifyCompleted(userId))
              .addCriteria(cursorIdCondition(cursorId))
              .with(Sort.by(Sort.Order.desc("timestamp")));
         return mongoTemplate.find(query, ChatMessage.class);
@@ -110,6 +123,10 @@ public class ChatMongoRepository {
         return Criteria.where("users.user_id").in(userId);
     }
 
+    private Criteria verifyValid() {
+        return Criteria.where("last_message").ne(null);
+    }
+
     private Criteria verifyActive() {
         return Criteria.where("chat_status").is(ChatRoomStatus.ACTIVE);
     }
@@ -120,6 +137,16 @@ public class ChatMongoRepository {
 
     private Criteria verifyLastMsgRead(Long userId) {
         return Criteria.where("last_message.read_by").nin(userId);
+    }
+
+    private Criteria verifyWaiting(Long userId) {
+        return Criteria.where("status").in(Status.WAITING, Status.COMPLETE)
+                       .and("sender_id").is(userId);
+    }
+
+    private Criteria verifyCompleted(Long userId) {
+        return Criteria.where("status").is(Status.COMPLETE)
+            .and("sender_id").ne(userId);
     }
 
     private Criteria cursorIdCondition(Long cursorId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
@@ -81,8 +81,7 @@ public class ChatMongoRepository {
         Query query = new Query();
         query.limit(pageSize + 1)
              .addCriteria(verifyRoomId(roomId))
-             .addCriteria(verifyWaiting(userId))
-             .addCriteria(verifyCompleted(userId))
+             .addCriteria(verifyStatus(userId))
              .addCriteria(cursorIdCondition(cursorId))
              .with(Sort.by(Sort.Order.desc("timestamp")));
         return mongoTemplate.find(query, ChatMessage.class);
@@ -148,6 +147,10 @@ public class ChatMongoRepository {
 
     private Criteria verifyMessageId(Long id) {
         return Criteria.where("_id").is(id);
+    }
+
+    private Criteria verifyStatus(Long userId) {
+        return new Criteria().orOperator(verifyWaiting(userId), verifyCompleted(userId));
     }
 
     private Criteria verifyWaiting(Long userId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/infrastructure/ChatMongoRepository.java
@@ -34,6 +34,13 @@ public class ChatMongoRepository {
         return mongoTemplate.save(chatMessage);
     }
 
+    public void update(ChatMessage chatMessage) {
+        Query query = new Query();
+        query.addCriteria(verifyMessageId(chatMessage.getId()));
+        Update update = new Update().set("status", chatMessage.getStatus());
+        mongoTemplate.updateFirst(query, update, ChatMessage.class);
+    }
+
     public Optional<ChatRoom> findByRoomId(@NonNull UUID roomId) {
         Query query = new Query();
         query.addCriteria(verifyId(roomId));
@@ -137,6 +144,10 @@ public class ChatMongoRepository {
 
     private Criteria verifyLastMsgRead(Long userId) {
         return Criteria.where("last_message.read_by").nin(userId);
+    }
+
+    private Criteria verifyMessageId(Long id) {
+        return Criteria.where("_id").is(id);
     }
 
     private Criteria verifyWaiting(Long userId) {

--- a/src/main/java/io/dev/jobprep/domain/chat/interceptor/StompInterceptor.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/interceptor/StompInterceptor.java
@@ -37,6 +37,7 @@ public class StompInterceptor implements ChannelInterceptor {
                 stompTokenProcessor.connect(accessor);
                 break;
             case SUBSCRIBE:
+                break;
             case SEND:
                 stompTokenProcessor.recoverMetaData(accessor);
                 break;

--- a/src/main/java/io/dev/jobprep/domain/chat/presentation/ChatRoomController.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/presentation/ChatRoomController.java
@@ -4,6 +4,7 @@ import io.dev.jobprep.common.base.CursorPaginationResult;
 import io.dev.jobprep.common.base.LongCursorPaginationReq;
 import io.dev.jobprep.common.base.StringCursorPaginationReq;
 import io.dev.jobprep.common.swagger.template.ChatSwagger;
+import io.dev.jobprep.domain.chat.application.ChatCommonService;
 import io.dev.jobprep.domain.chat.application.ChatService;
 import io.dev.jobprep.domain.chat.presentation.dto.res.ChatMessageCommonResponse;
 import io.dev.jobprep.domain.chat.presentation.dto.res.ChatRoomAdminResponse;
@@ -28,12 +29,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController implements ChatSwagger {
 
     private final ChatService chatService;
+    private final ChatCommonService chatCommonService;
 
     @PostMapping
     public ResponseEntity<ChatRoomIdResponse> create(@RequestParam Long userId) {
 
         return ResponseEntity.status(201)
             .body(ChatRoomIdResponse.from(chatService.create(userId)));
+    }
+
+    @GetMapping("/my/exist")
+    public ResponseEntity<ChatRoomIdResponse> getExistChatRoom(@RequestParam Long userId) {
+
+        return ResponseEntity.ok()
+            .body(ChatRoomIdResponse.from(chatCommonService.getChatRoom(userId)));
     }
 
     @GetMapping("/my")

--- a/src/main/java/io/dev/jobprep/domain/chat/presentation/dto/res/ChatMessageCommonResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/presentation/dto/res/ChatMessageCommonResponse.java
@@ -1,16 +1,19 @@
 package io.dev.jobprep.domain.chat.presentation.dto.res;
 
 import io.dev.jobprep.domain.chat.application.dto.res.ChatMessageCommonInfo;
+import io.dev.jobprep.domain.chat.domain.entity.enums.Status;
+import io.dev.jobprep.domain.users.application.dto.res.UserCommonInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 
 @Schema(description = "채팅 메시지 응답 Dto")
 @Getter
 public class ChatMessageCommonResponse {
 
-
+    @Schema(description = "메시지 ID", example = "1", implementation = Long.class)
     private final Long id;
 
     @Schema(description = "채팅 발신자 정보")
@@ -18,6 +21,9 @@ public class ChatMessageCommonResponse {
 
     @Schema(description = "채팅 메시지", example = "안녕하세요! 문의 드립니다!", implementation = String.class)
     private final String message;
+
+    @Schema(description = "메시지 상태", example = "전송 완료", implementation = String.class)
+    private final String status;
 
     @Schema(description = "채팅 메시지 생성일자", example = "2024-12-25T16:00:00", implementation = LocalDateTime.class)
     private final LocalDateTime createdAt;
@@ -27,22 +33,36 @@ public class ChatMessageCommonResponse {
         Long id,
         ChatUserCommonResponse chatSender,
         String message,
+        Status status,
         LocalDateTime createdAt
     ) {
         this.id = id;
         this.chatSender = chatSender;
         this.message = message;
+        this.status = resolve(status);
         this.createdAt = createdAt;
+    }
+
+    private String resolve(@NonNull final Status status) {
+        return status.getDescription();
     }
 
     public static ChatMessageCommonResponse from(ChatMessageCommonInfo commonInfo) {
 
         return ChatMessageCommonResponse.builder()
             .id(commonInfo.getId())
-            .chatSender(commonInfo.getSenderInfo() != null ? ChatUserCommonResponse.from(commonInfo.getSenderInfo()) : null)
+            .chatSender(resolve(commonInfo.getSenderInfo()))
             .message(commonInfo.getMessage())
+            .status(commonInfo.getStatus())
             .createdAt(commonInfo.getCreatedAt())
             .build();
+    }
+
+    private static ChatUserCommonResponse resolve(UserCommonInfo senderInfo) {
+        if (senderInfo == null) {
+            return null;
+        }
+        return ChatUserCommonResponse.from(senderInfo);
     }
 
 }

--- a/src/main/java/io/dev/jobprep/domain/chat/presentation/dto/res/ChatRoomIdResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/chat/presentation/dto/res/ChatRoomIdResponse.java
@@ -17,7 +17,14 @@ public class ChatRoomIdResponse {
     }
 
     public static ChatRoomIdResponse from(ChatRoom chatRoom) {
-        return new ChatRoomIdResponse(chatRoom.getId());
+        return new ChatRoomIdResponse(resolve(chatRoom));
+    }
+
+    private static UUID resolve(ChatRoom chatRoom) {
+        if (chatRoom == null) {
+            return null;
+        }
+        return chatRoom.getId();
     }
 
 }

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -43,6 +43,7 @@ public enum ErrorCode400 implements ErrorCode {
     NON_GATHERED_CHAT_USER("E01-CHATROOM-002", "해당 채팅방의 참여자가 아닙니다."),
     CHAT_ROOM_ALREADY_EXIST("E01-CHATROOM-003", "이미 생성된 채팅방이 있습니다."),
     CHAT_MISSING_DESTINATION("E01-CHATROOM-004", "채팅방 구독을 위한 목적지 정보가 잘못된 값입니다."),
+    ALREADY_COMPLETED_CHAT("E01-CHATROOM-005", "이미 전송이 완료된 채팅입니다."),
 
     SLACK_ALERT_FAILURE("E00-ALERT-001", "슬랙 채널로 메시지 전송에 실패했습니다."),
     ;

--- a/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
+++ b/src/main/java/io/dev/jobprep/exception/code/ErrorCode400.java
@@ -8,6 +8,7 @@ public enum ErrorCode400 implements ErrorCode {
     PATH_PARAMETER_BAD_REQUEST("E00-COMMON-001", "잘못된 경로 파라미터입니다."),
     INVALID_INPUT_VALUE("E00-COMMON-002", "기본 유효성 검사에 실패하였습니다."),
     ILLEGAL_INPUT_ARG("E00-COMMON-03", "유효하지 않은 입력 값입니다."),
+    UNSUPPORTED_FIELD_TYPE("E00-COMMON-04", "지원하지 않는 필드 타입입니다."),
 
     DUPLICATE_STUDY_NAME("E00-STUDY-01", "해당 스터디 이름이 이미 존재합니다."),
     INVALID_START_DATE("E00-STUDY-002", "스터디 시작 시간은 미래 시간이어야 합니다."),


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 첫 메시지 전송을 위한 채팅방 조회 API 구현 (내부적으로 확인하는 용도)
- [x] 채팅방 업데이트 실패로 인해, 메시지 수신이 실패한 채팅방에 대한 조회 API 리팩토링
        <에러 핸들링 시나리오>
        1. 채팅방 생성 성공
        2. 메시지 전송 성공
        3. 메시지 저장 성공
        4. 채팅방에 메시지 업데이트 실패 -> `채팅방 롤백 X`
        * 관리자의 채팅방 조회 API에는 정상적으로 메시지가 수신된 채팅방 리스트만 조회되도록 수정
- [x] 채팅방 조회 시 NPE 방지를 위한 resolve 로직 구현
- [x] `chatMessage` 컬렉션 및 도큐먼트에 메시지 전송 상태를 위한 `status` 필드 추가
         * `WAITING` : 대기중 (사용자가 채팅을 전송했으나, 네트워크 이슈 등의 예외로 인해 전송 실패 시)
         * `COMPLETE` : 전송 성공
- [x] 채팅 메시지 내역 조회 API에 실패한 메시지를 발신자에게만 조회되도록 리팩토링
        * `userA` 가 `admin` 에게 메시지를 전송했으나 `admin` 은 수신 실패
        * 해당 메시지는 `userA` 에게만 조회됨
- [x] `메시지 저장` 로직과 `채팅방 업데이트 및 메시지 상태 업데이트` 트랜잭션 분리
- [x] `채팅방 업데이트` 트랜잭션 실패 시, 예외의 상위 전파를 막아 해당 트랜잭션만 롤백되도록 try-catch 구현      

### 이슈 번호
- close #228

## 특이 사항 🫶 
