### PR TITLE
[INFRA] Window 환경을 위한 mongodb.key 권한 체킹하는 서비스 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,22 @@ services:
     networks:
       - app-network
 
+  init_permission:
+    image: nginx:latest
+    container_name: init_permission
+    restart: always
+    ports:
+      - "3015:80"
+    volumes:
+      - ${KEY_FILE_PATH}:/key
+    command: >
+      sh -c "cd key && chmod 400 mongodb.key && chown 999:999 mongodb.key && tail -f /dev/null"
+    healthcheck:
+      test: ["CMD", "sh", "-c", "sleep 2 && [ $(stat -c '%a' /key/mongodb.key 2>/dev/null) = 400 ] || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
   jobprep_mongo:
     image: mongo:6.0
     container_name: jobprep_mongo
@@ -35,6 +51,9 @@ services:
     ports:
       - "${MONGO_PORT}:27017"
     command: ["--replSet", "rs0", "--keyFile", "/etc/mongodb.key", "--bind_ip_all"]
+    depends_on:
+      init_permission:
+        condition: service_healthy
     healthcheck:
       test: >
         test $$(mongosh --port 27017 --quiet --eval "try {
@@ -72,6 +91,9 @@ services:
     ports:
       - "${MONGO_SECONDARY_01_PORT}:27017"
     command: ["--replSet", "rs0", "--keyFile", "/etc/mongodb.key", "--bind_ip_all"]
+    depends_on:
+      init_permission:
+        condition: service_healthy
     volumes:
       - mongodb_secondary_01_data:/data/db
       - ${MONGO_KEY_FILE_PATH}:/etc/mongodb.key
@@ -88,6 +110,9 @@ services:
     ports:
       - "${MONGO_SECONDARY_02_PORT}:27017"
     command: ["--replSet", "rs0", "--keyFile", "/etc/mongodb.key", "--bind_ip_all"]
+    depends_on:
+      init_permission:
+        condition: service_healthy
     volumes:
       - mongodb_secondary_02_data:/data/db
       - ${MONGO_KEY_FILE_PATH}:/etc/mongodb.key
@@ -108,7 +133,7 @@ services:
 
   app:
     container_name: jobprep-app
-    image: jobpreb/jobprep:40.0
+    image: jobpreb/jobprep:46.0
     restart: always
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://jobprep_mysql:3306/${MYSQL_DATABASE}


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 마운트된 `MongoDB.key` 파일 권한 체크하는 서비스 추가
- [x] MongoDB 환경으로 `replica-set`  설정하기 전 헬스체크 추가

### 이슈 번호
- close #237

## 특이 사항 🫶 
