### PR TITLE
[REFACT] Stomp 연결을 위한 임시 헤더 검증 제거, accessToken 기반 검증으로 변경

### DIFF
--- a/src/main/java/io/dev/jobprep/common/stomp/StompTokenProcessor.java
+++ b/src/main/java/io/dev/jobprep/common/stomp/StompTokenProcessor.java
@@ -3,6 +3,7 @@ package io.dev.jobprep.common.stomp;
 import io.dev.jobprep.domain.chat.application.ChatCommonService;
 import io.dev.jobprep.domain.chat.application.ChatService;
 import io.dev.jobprep.domain.chat.exception.ChatException;
+import io.dev.jobprep.domain.security.jwt.application.JwtService;
 import io.dev.jobprep.domain.users.application.UserCommonService;
 import io.dev.jobprep.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -29,10 +30,11 @@ public class StompTokenProcessor {
     private final UserCommonService userCommonService;
     private final ChatCommonService chatCommonService;
     private final ChatService chatService;
+    private final JwtService jwtService;
 
     public void connect(StompHeaderAccessor accessor) {
         UUID roomId = verifyDestination(accessor);
-        Long userId = verifyHeaderTemporary(accessor);
+        Long userId = verifyAccessToken(accessor);
         chatService.access(roomId, userId, accessor.getSessionId());
     }
 
@@ -42,8 +44,7 @@ public class StompTokenProcessor {
 
     public void recoverMetaData(StompHeaderAccessor accessor) {
         UUID roomId = verifyDestinationFromSubscription(accessor);
-        // TODO: 소셜 로그인 합친 후 accessToken 활용하도록 변경
-        Long userId = verifyHeaderTemporary(accessor);
+        Long userId = verifyAccessToken(accessor);
         chatService.recaching(roomId, userId, accessor.getSessionId());
     }
 
@@ -72,22 +73,12 @@ public class StompTokenProcessor {
         return UUID.fromString(subscription);
     }
 
-    private Long verifyHeaderTemporary(StompHeaderAccessor stompHeaderAccessor) {
-        String token = getTokenFromHeader(stompHeaderAccessor, TEMP_AUTHORIZATION, AUTH_MISSING_CREDENTIALS);
-        log.info("Received a temporary token from {}", token);
-        Long userId = Long.valueOf(token);
-        userCommonService.getUserWithId(userId);
-        return userId;
-    }
-
-    // TODO: 소셜 로그인 합칠 떄 변경
     private Long verifyAccessToken(StompHeaderAccessor stompHeaderAccessor) {
         String accessToken = getTokenFromHeader(stompHeaderAccessor, AUTHORIZATION_HEADER, AUTH_MISSING_CREDENTIALS);
-
-        // TODO: parsing Access Token to verify
-        // TODO: verify Access Token using JWT and return 'userId'
-
-        return null;
+        log.info("Received a access-token from {}", accessToken);
+        Long userId = jwtService.fetchFromToken(accessToken);
+        userCommonService.getUserWithId(userId);
+        return userId;
     }
 
     private String getTokenFromHeader(StompHeaderAccessor stompHeaderAccessor, String header, ErrorCode errorCode) {
@@ -100,5 +91,14 @@ public class StompTokenProcessor {
             throw new ChatException(errorCode);
         }
         return token;
+    }
+
+    @Deprecated
+    private Long verifyHeaderTemporary(StompHeaderAccessor stompHeaderAccessor) {
+        String token = getTokenFromHeader(stompHeaderAccessor, TEMP_AUTHORIZATION, AUTH_MISSING_CREDENTIALS);
+        log.info("Received a temporary token from {}", token);
+        Long userId = Long.valueOf(token);
+        userCommonService.getUserWithId(userId);
+        return userId;
     }
 }

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/JwtService.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/JwtService.java
@@ -8,6 +8,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
 import com.auth0.jwt.JWT;
 
+import io.dev.jobprep.domain.security.jwt.exception.TokenException;
 import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.Date;
+
+import static io.dev.jobprep.exception.code.ErrorCode401.AUTH_MISSING_CREDENTIALS;
 
 @Slf4j
 @Service
@@ -91,7 +94,17 @@ public class JwtService {
         }
     }
 
-    //토큰 만료 확인
+    public Long fetchFromToken(String token) {
+        try {
+            DecodedJWT decodedJWT = verifyNDecodeToken(token);
+            isTokenExpired(decodedJWT);
+            return Long.parseLong(extractUserId(decodedJWT));
+        } catch (Exception e) {
+            log.warn("Failed to verity and fetch userId from token: {}", e.getMessage());
+            throw new TokenException(AUTH_MISSING_CREDENTIALS);
+        }
+    }
+
     private void isTokenExpired(DecodedJWT decodedJWT) {
         boolean expired = decodedJWT.getExpiresAt().before(new Date());
         if(expired) {
@@ -100,7 +113,6 @@ public class JwtService {
         }
     }
 
-    // Verify and decode a JWT
     public DecodedJWT verifyNDecodeToken(String token) {
         try {
             JWTVerifier verifier = JWT.require(getAlgorithm()).build();
@@ -110,7 +122,6 @@ public class JwtService {
         }
     }
 
-    // Extract username (subject) from token
     public String extractUserId(DecodedJWT decodedJWT) {
         try {
             return decodedJWT.getSubject();
@@ -120,7 +131,6 @@ public class JwtService {
         }
     }
 
-    //Exract UserRole from token
     public String extractUserEmail(DecodedJWT decodedJWT) {
         try {
             return decodedJWT.getClaim("email").asString();


### PR DESCRIPTION
## 🚀 개발 사항
- [x] Stomp 연결을 위한 임시 헤더 검증 로직을 accessToken 기반 검증 로직으로 변경

### 이슈 번호
- close #243

## 특이 사항 🫶 
