### PR TITLE
[REFACT] health-check를 위해 간단한 내부 API 호출을 수행하도록 변경

### DIFF
--- a/src/main/java/io/dev/jobprep/common/actuator/ApplicationHealthIndicator.java
+++ b/src/main/java/io/dev/jobprep/common/actuator/ApplicationHealthIndicator.java
@@ -8,8 +8,10 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URL;
 
 @Slf4j
 @Component
@@ -18,30 +20,38 @@ public class ApplicationHealthIndicator implements HealthIndicator {
 
     private static final int DEFAULT_PORT = 8080;
     private static final String DEFAULT_HOST = "localhost";
-    private static final String PING_COMMAND = "ping -c 1 localhost";
     private static final String DEFAULT_STATE = "UP";
     private static final String BLUE = "34.22.104.185";
+    private static final String PREFIX = "http://";
+    private static final String HEALTH_URL = "/internal/health/server";
 
     private final HttpServletRequest httpServletRequest;
 
     @Override
     public Health health() {
 
-        boolean pingStatus = isPingSuccessful();
+        boolean httpStatus = isServerReachable();
         boolean portStatus = isPortOpen();
-        log.info("Application health-check in ping '{}', port '{}'", convert(pingStatus), convert(portStatus));
+        log.info("Application health-check in server '{}', port '{}'", convert(httpStatus), convert(portStatus));
 
-        return adaptiveFetchHealth(pingStatus, portStatus);
+        return adaptiveFetchHealth(httpStatus, portStatus);
     }
 
-    private boolean isPingSuccessful() {
+    private boolean isServerReachable() {
         try {
-            Process process = Runtime.getRuntime().exec(PING_COMMAND);
-            int exitCode = process.waitFor();
-            return exitCode == 0;
-        } catch (IOException | InterruptedException e) {
+            URL url = new URL(makeUrl());
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(5000);
+            connection.connect();
+            return connection.getResponseCode() == 200;
+        } catch (Exception e) {
             return false;
         }
+    }
+
+    private String makeUrl() {
+        return PREFIX + DEFAULT_HOST + ":" + DEFAULT_PORT + HEALTH_URL;
     }
 
     private boolean isPortOpen() {
@@ -53,21 +63,21 @@ public class ApplicationHealthIndicator implements HealthIndicator {
         }
     }
 
-    private Health adaptiveFetchHealth(boolean pingStatus, boolean portStatus) {
-        return pingStatus && portStatus ? healthy() : unhealthy(pingStatus, portStatus);
+    private Health adaptiveFetchHealth(boolean httpStatus, boolean portStatus) {
+        return httpStatus && portStatus ? healthy() : unhealthy(httpStatus, portStatus);
     }
 
     private Health healthy() {
         return Health.up()
-                .withDetail("Ping", DEFAULT_STATE)
+                .withDetail("Http", DEFAULT_STATE)
                 .withDetail("Port", DEFAULT_STATE)
                 .withDetail("Server", getServerIp())
                 .build();
     }
 
-    private Health unhealthy(boolean pingStatus, boolean portStatus) {
+    private Health unhealthy(boolean httpStatus, boolean portStatus) {
         return Health.down()
-                .withDetail("Ping", convert(pingStatus))
+                .withDetail("Http", convert(httpStatus))
                 .withDetail("Port", convert(portStatus))
                 .withDetail("Server", getServerIp())
                 .build();
@@ -79,6 +89,7 @@ public class ApplicationHealthIndicator implements HealthIndicator {
 
     private String getServerIp() {
         String serverIp = httpServletRequest.getLocalAddr();
+        log.info("incoming server IP: {}", serverIp);
         return serverIp.equals(BLUE) ? "BLUE" : "GREEN";
     }
 }

--- a/src/main/java/io/dev/jobprep/system/internal/health/HealthCheckController.java
+++ b/src/main/java/io/dev/jobprep/system/internal/health/HealthCheckController.java
@@ -4,12 +4,12 @@ import io.dev.jobprep.common.actuator.ApplicationHealthIndicator;
 import io.dev.jobprep.system.internal.developer.DeveloperTokenHelper;
 import io.dev.jobprep.util.IpAddressHelper;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -21,6 +21,11 @@ public class HealthCheckController {
 
     private final ApplicationHealthIndicator healthIndicator;
     private final DeveloperTokenHelper developerTokenHelper;
+
+    @GetMapping("/server")
+    public ResponseEntity<Void> serverHealthCheck(HttpServletRequest req, HttpServletResponse res) {
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 
     @PutMapping("/up")
     public void up(HttpServletRequest request, @RequestHeader(AUTHORIZATION) String token) {


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 서버의 `health-check` 를 위한 로직을 내부 API 호출 로직으로 변경

### 이슈 번호
- close #249

## 특이 사항 🫶 
