### PR TITLE
[BUG] Github Actions에서 upload-artifact deprecated version 오류 해결

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -198,7 +198,7 @@ jobs:
       # 16. upload test-results
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-test-results
           path: test-results/ # directory for test-results


### PR DESCRIPTION
## 🚀 개발 사항
- [x] GitHub actions 스크립트에서 `upload-artifact` deprecated version 오류 해결을 위해 `v3` -> `v4` 업그레이드

### 이슈 번호
- close #254

## 특이 사항 🫶 
