### PR TITLE
Bug/#257 OAuth2 인증 성공 후 redirect 호출 시, /login에 걸리는 문제 해결 ( + JwtFilter를 타지 않도록 변경 )

### DIFF
--- a/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
@@ -120,7 +120,8 @@ public class SecurityConfig {
         return web -> web.ignoring()
                 .requestMatchers(
                         "/actuator/**",
-                        "/api/v1/oauth2/reissue"
+                        "/api/v1/oauth2/reissue",
+                        "/oauth/callback"
                 );
     }
 }

--- a/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                 "/api/v1/oauth2/callback",
                                 "/login/oauth2/code/**",
                                 "/oauth2/authorization/**",
+                                "/oauth2/callback",
                                 "/api-docs/**",
                                 "/swagger-ui/**",
                                 "/actuator/**",

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthService.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthService.java
@@ -27,7 +27,6 @@ public class AuthService {
     private final JwtRedisService jwtRedisService;
     private final PrincipalDetailsService principalDetailsService;
 
-
     @Value("${jwt.refresh-token-validity}")
     private Long refreshTokenValidity;
 
@@ -42,10 +41,7 @@ public class AuthService {
     public void deleteFromCache(PrincipalDetails principalDetails){
         SecurityContextHolder.clearContext();
         String userId = principalDetails.getUsername();
-
-
         jwtRedisService.deleteRefreshToken(userId);
-
     }
 
     public void bakeCookieIntoResponse(TokenInfo tokenInfo,
@@ -82,8 +78,5 @@ public class AuthService {
 
         return tokenInfo;
     }
-
-
-
 
 }

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -32,7 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> EXCLUDE_PATHS = Arrays.asList(
             "/actuator",
-            "/api/v1/oauth2/reissue"
+            "/api/v1/oauth2/reissue",
+            "/oauth/callback"
     );
 
     @Override

--- a/src/main/java/io/dev/jobprep/domain/security/oauth/application/OAuth2SuccessHandler.java
+++ b/src/main/java/io/dev/jobprep/domain/security/oauth/application/OAuth2SuccessHandler.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 @Component
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final OAuthRedisService oAuthRedisService;
+
     @Value("${spring.security.oauth2.frontend-redirect.url}")
     private String redirectUrl;
 


### PR DESCRIPTION
## 🚀 개발 사항
- [x] `OAuth2SuccessHandler` 에서 redirect를 위한 엔드포인트에 `permitAll` 부여
- [x] redirect 엔드포인트에 `JwtFilter` 가 걸리지 않도록 변경

### 이슈 번호
- close #257

## 특이 사항 🫶 
