### PR TITLE
Bug/#264 OAuth2 인증 시, OTP 토큰 발급이 실패하는 문제 해결 ( + redirect_uri에 대한 401 에러 해결 )

### DIFF
--- a/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
@@ -44,8 +44,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/oauth2/reissue",
                                 "/api/v1/oauth2/callback",
-                                "/login/oauth2/code/**",
                                 "/oauth2/authorization/**",
+                                "/login/oauth2/code/**",
                                 "/oauth/callback",
                                 "/api-docs/**",
                                 "/swagger-ui/**",
@@ -122,6 +122,7 @@ public class SecurityConfig {
                 .requestMatchers(
                         "/actuator/**",
                         "/api/v1/oauth2/reissue",
+                        "/login/oauth2/code",
                         "/oauth/callback"
                 );
     }

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final List<String> EXCLUDE_PATHS = Arrays.asList(
             "/actuator",
             "/api/v1/oauth2/reissue",
+            "/login/oauth2/code",
             "/oauth/callback"
     );
 

--- a/src/main/java/io/dev/jobprep/domain/security/oauth/application/CustomOAuth2UserService.java
+++ b/src/main/java/io/dev/jobprep/domain/security/oauth/application/CustomOAuth2UserService.java
@@ -36,6 +36,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, oAuth2UserAttributes);
         User user = fetchAndSaveIfAbsent(attributes);
+        log.info("Registered user '{}' with successful OAuth Authentication", user.getEmail());
         return new PrincipalDetails(user, oAuth2UserAttributes, userNameAttributeName);
     }
 

--- a/src/main/java/io/dev/jobprep/domain/security/oauth/application/OAuth2SuccessHandler.java
+++ b/src/main/java/io/dev/jobprep/domain/security/oauth/application/OAuth2SuccessHandler.java
@@ -48,7 +48,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                         .collect(Collectors.joining(","))
         );
 
-        String otpToken = generateToken();
+        log.info("Successfully authenticated user '{}'", userInfo.getEmail());
+
+        String otpToken = createNewToken();
         oauthCacheService.cache(otpToken, userInfo, Duration.ofMinutes(5));
 
         response.sendRedirect(generateRedirectUrl(otpToken));
@@ -58,7 +60,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         return redirectUrl + QUERY_PARAMETER + TokenHeaderConstants.OTP_HEADER + EQUAVALENT + otpToken;
     }
 
-    private String generateToken() {
+    private String createNewToken() {
         return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/io/dev/jobprep/domain/security/oauth/domain/OAuthAttributes.java
+++ b/src/main/java/io/dev/jobprep/domain/security/oauth/domain/OAuthAttributes.java
@@ -70,7 +70,7 @@ public class OAuthAttributes {
     private static List<String> fetchInfoFromAttributes(String social, Map<String, Object> attributes) {
         if (KAKAO.equals(social)) {
             Map<String, Object> account = fetchAttribute(attributes, "kakao_account");
-            Map<String, Object> profile = fetchAttribute(attributes, "profile");
+            Map<String, Object> profile = fetchAttribute(account, "profile");
             return Arrays.asList(
                     String.valueOf(profile.get(NICKNAME)),
                     String.valueOf(account.get(EMAIL))


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 소셜 로그인 플랫폼 인증 서버의 `redirect-uri` 에 대한 401 에러 해결 -> `shouldNotFilter` 에 추가 
- [x] 소셜 로그인의 `attributes` 의 `NPE` 문제 해결

### 이슈 번호
- close #264

## 특이 사항 🫶 
