### PR TITLE
Feat/#265 로컬 스테이징 환경을 위한 자체 로그인 Auth 엔드포인트 구현

### DIFF
--- a/src/main/java/io/dev/jobprep/common/swagger/template/AuthSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/AuthSwagger.java
@@ -1,0 +1,37 @@
+package io.dev.jobprep.common.swagger.template;
+
+import io.dev.jobprep.core.properties.swagger.error.SwaggerJwtErrorExamples;
+import io.dev.jobprep.domain.security.auth.presentation.dto.req.AuthLoginRequest;
+import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
+import io.dev.jobprep.exception.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "테스트용 로그인 API")
+@SuppressWarnings("unused")
+public interface AuthSwagger {
+
+    @Operation(summary = "로그인", description = "테스트용 Freepass 토큰을 발급받기 위해 사용하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인 실패",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(name = "E02-AUTH-001", value = SwaggerJwtErrorExamples.AUTH_MISSING_CREDENTIALS)
+                ))
+    })
+    ResponseEntity<TokenResponse> login(
+            @Valid @RequestBody AuthLoginRequest request,
+            HttpServletResponse response
+    );
+}

--- a/src/main/java/io/dev/jobprep/common/swagger/template/AuthSwagger.java
+++ b/src/main/java/io/dev/jobprep/common/swagger/template/AuthSwagger.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,8 +29,5 @@ public interface AuthSwagger {
                     examples = @ExampleObject(name = "E02-AUTH-001", value = SwaggerJwtErrorExamples.AUTH_MISSING_CREDENTIALS)
                 ))
     })
-    ResponseEntity<TokenResponse> login(
-            @Valid @RequestBody AuthLoginRequest request,
-            HttpServletResponse response
-    );
+    ResponseEntity<TokenResponse> login(@Valid @RequestBody AuthLoginRequest request);
 }

--- a/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
+++ b/src/main/java/io/dev/jobprep/core/configuration/SecurityConfig.java
@@ -6,6 +6,7 @@ import io.dev.jobprep.domain.security.oauth.application.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,9 +38,30 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
+    public SecurityFilterChain nonOAuth2SecurityFilterChain(HttpSecurity http) throws Exception {
+        configureCommonSecuritySettings(http);
+        return http
+                .securityMatcher(new AntPathRequestMatcher("/api/v1/auth/**"))
+                .authorizeHttpRequests(auth -> auth
+                    .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(handling ->
+                    handling
+                        .authenticationEntryPoint(entryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .sessionManagement(session ->
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+        .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain authenticationFilterChain(HttpSecurity http) throws Exception {
         configureCommonSecuritySettings(http);
-        http
+        return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/oauth2/reissue",
@@ -68,9 +90,8 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                );
-
-        return http.build();
+                )
+        .build();
     }
 
     private void configureCommonSecuritySettings(HttpSecurity httpSecurity) throws Exception {
@@ -120,6 +141,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(
+                        "/api/v1/auth/login",
                         "/actuator/**",
                         "/api/v1/oauth2/reissue",
                         "/login/oauth2/code",

--- a/src/main/java/io/dev/jobprep/domain/essentialMaterial/presentation/dto/EssentialMaterialController.java
+++ b/src/main/java/io/dev/jobprep/domain/essentialMaterial/presentation/dto/EssentialMaterialController.java
@@ -19,7 +19,7 @@ public class EssentialMaterialController implements EssentialMaterialSwagger {
     private final EssentialMaterialService essentialMaterialService;
     private final UserCommonService userCommonService;
 
-    @GetMapping(value = "/")
+    @GetMapping
     public ResponseEntity<EssentialMaterialGetAPIResponse> get(@JwtToken Long userId){
         String material = essentialMaterialService.get(userCommonService.getUserWithId(userId));
         return ResponseEntity.ok(new EssentialMaterialGetAPIResponse(material));

--- a/src/main/java/io/dev/jobprep/domain/security/auth/application/AuthService.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/application/AuthService.java
@@ -5,7 +5,6 @@ import io.dev.jobprep.domain.security.jwt.application.AuthIntegrationManager;
 import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
 import io.dev.jobprep.domain.users.application.UserCommonService;
 import io.dev.jobprep.domain.users.domain.User;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,9 +17,9 @@ public class AuthService {
     private final UserCommonService userCommonService;
     private final AuthIntegrationManager authIntegrationManager;
 
-    public TokenResponse login(AuthLoginRequest request, final HttpServletResponse response) {
+    public TokenResponse login(AuthLoginRequest request) {
         User developer = verifyDeveloper(request.getId());
-        return authIntegrationManager.issueTokenViaNonOAuth(response, developer);
+        return authIntegrationManager.issueTokenViaNonOAuth(developer);
     }
 
     private User verifyDeveloper(String email) {

--- a/src/main/java/io/dev/jobprep/domain/security/auth/application/AuthService.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/application/AuthService.java
@@ -1,0 +1,30 @@
+package io.dev.jobprep.domain.security.auth.application;
+
+import io.dev.jobprep.domain.security.auth.presentation.dto.req.AuthLoginRequest;
+import io.dev.jobprep.domain.security.jwt.application.AuthIntegrationManager;
+import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
+import io.dev.jobprep.domain.users.application.UserCommonService;
+import io.dev.jobprep.domain.users.domain.User;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserCommonService userCommonService;
+    private final AuthIntegrationManager authIntegrationManager;
+
+    public TokenResponse login(AuthLoginRequest request, final HttpServletResponse response) {
+        User developer = verifyDeveloper(request.getId());
+        return authIntegrationManager.issueTokenViaNonOAuth(response, developer);
+    }
+
+    private User verifyDeveloper(String email) {
+        return userCommonService.getUserWithEmail(email);
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
@@ -1,5 +1,6 @@
 package io.dev.jobprep.domain.security.auth.presentation;
 
+import io.dev.jobprep.common.swagger.template.AuthSwagger;
 import io.dev.jobprep.domain.security.auth.application.AuthService;
 import io.dev.jobprep.domain.security.auth.presentation.dto.req.AuthLoginRequest;
 import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 @RestController
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthSwagger {
 
     private final AuthService authService;
 

--- a/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
@@ -1,0 +1,28 @@
+package io.dev.jobprep.domain.security.auth.presentation;
+
+import io.dev.jobprep.domain.security.auth.application.AuthService;
+import io.dev.jobprep.domain.security.auth.presentation.dto.req.AuthLoginRequest;
+import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody AuthLoginRequest request,
+                                               HttpServletResponse response) {
+        return ResponseEntity.ok(authService.login(request, response));
+    }
+
+}

--- a/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/presentation/AuthController.java
@@ -4,7 +4,6 @@ import io.dev.jobprep.common.swagger.template.AuthSwagger;
 import io.dev.jobprep.domain.security.auth.application.AuthService;
 import io.dev.jobprep.domain.security.auth.presentation.dto.req.AuthLoginRequest;
 import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +20,8 @@ public class AuthController implements AuthSwagger {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@Valid @RequestBody AuthLoginRequest request,
-                                               HttpServletResponse response) {
-        return ResponseEntity.ok(authService.login(request, response));
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody AuthLoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
     }
 
 }

--- a/src/main/java/io/dev/jobprep/domain/security/auth/presentation/dto/req/AuthLoginRequest.java
+++ b/src/main/java/io/dev/jobprep/domain/security/auth/presentation/dto/req/AuthLoginRequest.java
@@ -1,0 +1,21 @@
+package io.dev.jobprep.domain.security.auth.presentation.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "임시로 사용하는 자체 로그 요청 DTO")
+@Getter
+@NoArgsConstructor
+public class AuthLoginRequest {
+
+    @Schema(description = "아이디", example = "jobprep12321@gmail.com", implementation = String.class)
+    @NotBlank
+    private String id;
+
+    @Schema(description = "비밀번호", example = "password!123", implementation = String.class)
+    @NotBlank
+    private String password;
+
+}

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
@@ -11,6 +11,7 @@ import io.dev.jobprep.domain.security.oauth.application.dto.OAuthUserInfo;
 import io.dev.jobprep.domain.security.oauth.domain.PrincipalDetails;
 import io.dev.jobprep.domain.security.jwt.application.dto.JwtToken;
 import io.dev.jobprep.domain.security.oauth.presentation.dto.res.TokenResponse;
+import io.dev.jobprep.domain.users.domain.User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,12 @@ public class AuthIntegrationManager {
             throw new IllegalStateException("Invalid OTP token");
         }
         AuthenticationToken token = issue(userInfo.getUserId());
+        bakeCookie(token.getJwtToken(), response);
+        return TokenResponse.of(token);
+    }
+
+    public TokenResponse issueTokenViaNonOAuth(final HttpServletResponse response, User developer) {
+        AuthenticationToken token = issue(String.valueOf(developer.getId()));
         bakeCookie(token.getJwtToken(), response);
         return TokenResponse.of(token);
     }

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
@@ -47,7 +47,7 @@ public class AuthIntegrationManager {
     }
 
     public TokenResponse issueTokenViaNonOAuth(final HttpServletResponse response, User developer) {
-        AuthenticationToken token = issue(String.valueOf(developer.getId()));
+        AuthenticationToken token = issueForFP(String.valueOf(developer.getId()));
         bakeCookie(token.getJwtToken(), response);
         return TokenResponse.of(token);
     }
@@ -66,6 +66,14 @@ public class AuthIntegrationManager {
     private AuthenticationToken issue(String userId) {
         PrincipalDetails principalDetails = (PrincipalDetails) principalDetailsService.loadUserByUsername(userId);
         JwtToken jwtToken = jwtTokenProvider.sign(userId, principalDetails.getEmail(), principalDetails.getUserRoles());
+        CsrfToken csrfToken = csrfTokenProvider.sign(userId);
+        tokenCacheAggregator.cache(userId, jwtToken, csrfToken);
+        return AuthenticationToken.of(jwtToken, csrfToken);
+    }
+
+    private AuthenticationToken issueForFP(String userId) {
+        PrincipalDetails principalDetails = (PrincipalDetails) principalDetailsService.loadUserByUsername(userId);
+        JwtToken jwtToken = jwtTokenProvider.signForFP(userId, principalDetails.getEmail(), principalDetails.getUserRoles());
         CsrfToken csrfToken = csrfTokenProvider.sign(userId);
         tokenCacheAggregator.cache(userId, jwtToken, csrfToken);
         return AuthenticationToken.of(jwtToken, csrfToken);

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/AuthIntegrationManager.java
@@ -46,9 +46,8 @@ public class AuthIntegrationManager {
         return TokenResponse.of(token);
     }
 
-    public TokenResponse issueTokenViaNonOAuth(final HttpServletResponse response, User developer) {
+    public TokenResponse issueTokenViaNonOAuth(User developer) {
         AuthenticationToken token = issueForFP(String.valueOf(developer.getId()));
-        bakeCookie(token.getJwtToken(), response);
         return TokenResponse.of(token);
     }
 
@@ -74,9 +73,7 @@ public class AuthIntegrationManager {
     private AuthenticationToken issueForFP(String userId) {
         PrincipalDetails principalDetails = (PrincipalDetails) principalDetailsService.loadUserByUsername(userId);
         JwtToken jwtToken = jwtTokenProvider.signForFP(userId, principalDetails.getEmail(), principalDetails.getUserRoles());
-        CsrfToken csrfToken = csrfTokenProvider.sign(userId);
-        tokenCacheAggregator.cache(userId, jwtToken, csrfToken);
-        return AuthenticationToken.of(jwtToken, csrfToken);
+        return AuthenticationToken.of(jwtToken, null);
     }
 
     private AuthenticationToken reissue(String refreshToken, String csrfToken) {

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/application/provider/JwtTokenProvider.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/application/provider/JwtTokenProvider.java
@@ -27,6 +27,7 @@ public class JwtTokenProvider {
     private static final String USER_ROLE = "auth";
     private static final String USER_EMAIL = "email";
     private static final String MASKER = "*****";
+    private static final Long MONTH = 2_592_000_000L;
 
     @Value("${jwt.secret-key}")
     private String secretKey;
@@ -51,6 +52,14 @@ public class JwtTokenProvider {
         return JwtToken.of(TYPE, accessToken, refreshToken);
     }
 
+    public JwtToken signForFP(String userId, String userEmail, String userRoles) {
+
+        String accessToken = signAccessTokenForFP(userId, userEmail, userRoles);
+        log.info("Signed accessToken for FP '{}'", masking(accessToken));
+
+        return JwtToken.of(TYPE, accessToken, null);
+    }
+
     private String signAccessToken(String userId, String userEmail, String userRoles) {
         return JWT.create()
                 .withSubject(userId)
@@ -58,6 +67,16 @@ public class JwtTokenProvider {
                 .withClaim(USER_EMAIL, userEmail)
                 .withIssuedAt(getCurrentDate())
                 .withExpiresAt(calculateExpiryDate(accessTokenValidityTime))
+                .sign(getAlgorithm());
+    }
+
+    private String signAccessTokenForFP(String userId, String userEmail, String userRoles) {
+        return JWT.create()
+                .withSubject(userId)
+                .withClaim(USER_ROLE, userRoles)
+                .withClaim(USER_EMAIL, userEmail)
+                .withIssuedAt(getCurrentDate())
+                .withExpiresAt(calculateExpiryDate(MONTH))
                 .sign(getAlgorithm());
     }
 

--- a/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/dev/jobprep/domain/security/jwt/filter/JwtAuthenticationFilter.java
@@ -30,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final PrincipalDetailsService principalDetailsService;
 
     private static final List<String> EXCLUDE_PATHS = Arrays.asList(
+            "/api/v1/auth/login",
             "/actuator",
             "/api/v1/oauth2/reissue",
             "/login/oauth2/code",

--- a/src/main/java/io/dev/jobprep/domain/security/oauth/presentation/dto/res/TokenResponse.java
+++ b/src/main/java/io/dev/jobprep/domain/security/oauth/presentation/dto/res/TokenResponse.java
@@ -19,6 +19,10 @@ public class TokenResponse {
     }
 
     public static TokenResponse of(AuthenticationToken token) {
-        return new TokenResponse(token.getJwtToken().getAccessToken(), token.getCsrfToken().getToken());
+        return new TokenResponse(token.getJwtToken().getAccessToken(), resolveCsrfToken(token));
+    }
+
+    private static String resolveCsrfToken(AuthenticationToken token) {
+        return token.getCsrfToken() == null ? null : token.getCsrfToken().getToken();
     }
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] `dev` 용 서버에서 로컬 스테이징 환경으로 사용할 Auth 엔드포인트 구현 ( 임시용, production 배포 ❌ )
- [x] `refreshToken` `csrfToken` 발급 ❌

### 이슈 번호
- close #265

## 특이 사항 🫶 
